### PR TITLE
plurals rule should always follow with language

### DIFF
--- a/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
+++ b/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
@@ -117,7 +117,6 @@ public class PatternServiceImpl implements IPatternService {
 			patternJson = patternDao.getPattern(locale, null);
 			if (StringUtils.isEmpty(patternJson)) {
 				logger.info("file data don't exist");
-				resultData.setPluralSearch(true);
 				return buildPatternMap(language, region, patternJson, categoryList, resultData);
 			}
 			TranslationCache3.addCachedObject(CacheName.PATTERN, locale, String.class, patternJson);
@@ -151,7 +150,7 @@ public class PatternServiceImpl implements IPatternService {
 			patternMap.put(ConstantsKeys.IS_EXIST_PATTERN, true);
 		}
 
-		if (categoryList.contains(ConstantsKeys.PLURALS) && localeDataDTO.isPluralSearch()) {
+		if (categoryList.contains(ConstantsKeys.PLURALS)) {
 			String tempLanguage = language.split("-")[0];
 			Map<String, Object> plurals = CommonUtil.getMatchingPluralByLanguage(tempLanguage);
 			Map<String, Object> pluralRulesMap = new LinkedHashMap<>();

--- a/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
+++ b/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import javax.annotation.Resource;
 
+import com.vmware.i18n.PatternUtil;
 import com.vmware.i18n.dto.LocaleDataDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +75,13 @@ public class PatternServiceImpl implements IPatternService {
 		}
 		logger.info("get pattern data from cache");
 		patternMap = JSONUtils.getMapFromJson(patternJson);
+		if (StringUtils.isEmpty(patternMap.get(ConstantsKeys.REGION))) {
+			String regionJson = PatternUtil.getRegionFromLib(locale.replace("_", "-"));
+			if (!StringUtils.isEmpty(regionJson)) {
+				Object region = JSONUtils.getMapFromJson(regionJson).get(ConstantsKeys.DEFAULT_REGION_CODE);
+				patternMap.put(ConstantsKeys.REGION, region.toString());
+			}
+		}
 		patternMap.put(ConstantsKeys.CATEGORIES, getCategories(categoryList, patternMap));
 		return patternMap;
 	}

--- a/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
+++ b/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
@@ -117,7 +117,7 @@ public class PatternServiceImpl implements IPatternService {
 			patternJson = patternDao.getPattern(locale, null);
 			if (StringUtils.isEmpty(patternJson)) {
 				logger.info("file data don't exist");
-				resultData.setInvalid(true);
+				resultData.setPluralSearch(true);
 				return buildPatternMap(language, region, patternJson, categoryList, resultData);
 			}
 			TranslationCache3.addCachedObject(CacheName.PATTERN, locale, String.class, patternJson);
@@ -151,7 +151,7 @@ public class PatternServiceImpl implements IPatternService {
 			patternMap.put(ConstantsKeys.IS_EXIST_PATTERN, true);
 		}
 
-		if (categoryList.contains(ConstantsKeys.PLURALS) && localeDataDTO.isInvalid()) {
+		if (categoryList.contains(ConstantsKeys.PLURALS) && localeDataDTO.isPluralSearch()) {
 			String tempLanguage = language.split("-")[0];
 			Map<String, Object> plurals = CommonUtil.getMatchingPluralByLanguage(tempLanguage);
 			Map<String, Object> pluralRulesMap = new LinkedHashMap<>();
@@ -160,7 +160,7 @@ public class PatternServiceImpl implements IPatternService {
 			patternMap.put(ConstantsKeys.IS_EXIST_PATTERN, true);
 		}
 
-		if (!localeDataDTO.isDisplay()) {
+		if (!localeDataDTO.isDisplayLocaleID()) {
 			patternMap.put(ConstantsKeys.LOCALEID, "");
 		}
 

--- a/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
+++ b/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
@@ -19,7 +19,6 @@ import com.vmware.i18n.dto.LocaleDataDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import com.vmware.i18n.l2.dao.pattern.IPatternDao;
 import com.vmware.i18n.utils.CommonUtil;
@@ -28,6 +27,7 @@ import com.vmware.vip.common.cache.TranslationCache3;
 import com.vmware.vip.common.constants.ConstantsKeys;
 import com.vmware.vip.common.exceptions.VIPCacheException;
 import com.vmware.vip.common.utils.JSONUtils;
+import org.springframework.util.StringUtils;
 
 @Service
 public class PatternServiceImpl implements IPatternService {
@@ -77,7 +77,7 @@ public class PatternServiceImpl implements IPatternService {
 		patternMap = JSONUtils.getMapFromJson(patternJson);
 		if (StringUtils.isEmpty(patternMap.get(ConstantsKeys.REGION))) {
 			String regionJson = PatternUtil.getRegionFromLib(locale.replace("_", "-"));
-			if (!StringUtils.isEmpty(regionJson)) {
+			if (StringUtils.hasLength(regionJson)) {
 				Object region = JSONUtils.getMapFromJson(regionJson).get(ConstantsKeys.DEFAULT_REGION_CODE);
 				patternMap.put(ConstantsKeys.REGION, region.toString());
 			}

--- a/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
+++ b/g11n-ws/modules/md-service-i18n-l2/src/main/java/com/vmware/i18n/l2/service/pattern/PatternServiceImpl.java
@@ -110,12 +110,12 @@ public class PatternServiceImpl implements IPatternService {
 			if (StringUtils.isEmpty(patternJson)) {
 				logger.info("file data don't exist");
 				resultData.setInvalid(true);
-				return buildPatternMap(language, region, patternJson, categoryList, resultData.isInvalid());
+				return buildPatternMap(language, region, patternJson, categoryList, resultData);
 			}
 			TranslationCache3.addCachedObject(CacheName.PATTERN, locale, String.class, patternJson);
 		}
 		logger.info("get pattern data from cache");
-		patternMap = buildPatternMap(language, region, patternJson, categoryList, resultData.isInvalid());
+		patternMap = buildPatternMap(language, region, patternJson, categoryList, resultData);
 		logger.info("The result pattern: {}", patternMap);
 		logger.info("Get i18n pattern successful");
 		return patternMap;
@@ -128,7 +128,7 @@ public class PatternServiceImpl implements IPatternService {
 	 * @param categoryList
 	 * @return
 	 */
-	private Map<String, Object> buildPatternMap(String language, String region, String patternJson, List<String> categoryList, boolean isInvalid) {
+	private Map<String, Object> buildPatternMap(String language, String region, String patternJson, List<String> categoryList, LocaleDataDTO localeDataDTO) {
 		Map<String, Object> patternMap = new LinkedHashMap<>();
 		Map<String, Object> categoriesMap = new LinkedHashMap<>();
 		if (StringUtils.isEmpty(patternJson)) {
@@ -143,8 +143,7 @@ public class PatternServiceImpl implements IPatternService {
 			patternMap.put(ConstantsKeys.IS_EXIST_PATTERN, true);
 		}
 
-		if (categoryList.contains(ConstantsKeys.PLURALS) && isInvalid) {
-			patternMap.put(ConstantsKeys.LOCALEID, "");
+		if (categoryList.contains(ConstantsKeys.PLURALS) && localeDataDTO.isInvalid()) {
 			String tempLanguage = language.split("-")[0];
 			Map<String, Object> plurals = CommonUtil.getMatchingPluralByLanguage(tempLanguage);
 			Map<String, Object> pluralRulesMap = new LinkedHashMap<>();
@@ -152,6 +151,11 @@ public class PatternServiceImpl implements IPatternService {
 			categoriesMap.put(ConstantsKeys.PLURALS, pluralRulesMap);
 			patternMap.put(ConstantsKeys.IS_EXIST_PATTERN, true);
 		}
+
+		if (!localeDataDTO.isDisplay()) {
+			patternMap.put(ConstantsKeys.LOCALEID, "");
+		}
+
 		patternMap.put(ConstantsKeys.LANGUAGE, language);
 		patternMap.put(ConstantsKeys.REGION, region);
 		patternMap.put(ConstantsKeys.CATEGORIES, categoriesMap);

--- a/g11n-ws/tools/tool-cldr-extractor/build.gradle
+++ b/g11n-ws/tools/tool-cldr-extractor/build.gradle
@@ -5,7 +5,7 @@ description = 'VIP i18n pattern CLDR data extract tools'
 ext {
     javaLevel = 1.8
     cldrVersion = '32.0.0'
-    projectVersion = '0.10.31'
+    projectVersion = '0.10.32'
     deployPath="$rootDir/../publish/"
     sourceCompatibility = javaLevel
     version = '1.0'

--- a/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/dto/LocaleDataDTO.java
+++ b/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/dto/LocaleDataDTO.java
@@ -7,11 +7,11 @@ package com.vmware.i18n.dto;
 public class LocaleDataDTO {
     private String locale;
 
-    // Whether the locale obtained by language+region is valid
-    private boolean isInvalid = false;
+    // Whether need to query default region based on language
+    private boolean pluralSearch = false;
 
     // Whether the LocaleID needs to be displayed
-    private boolean isDisplay = true;
+    private boolean displayLocaleID = true;
 
     public String getLocale() {
         return locale;
@@ -21,19 +21,19 @@ public class LocaleDataDTO {
         this.locale = locale;
     }
 
-    public boolean isInvalid() {
-        return isInvalid;
+    public boolean isPluralSearch() {
+        return pluralSearch;
     }
 
-    public void setInvalid(boolean invalid) {
-        isInvalid = invalid;
+    public void setPluralSearch(boolean pluralSearch) {
+        this.pluralSearch = pluralSearch;
     }
 
-    public boolean isDisplay() {
-        return isDisplay;
+    public boolean isDisplayLocaleID() {
+        return displayLocaleID;
     }
 
-    public void setDisplay(boolean display) {
-        isDisplay = display;
+    public void setDisplayLocaleID(boolean displayLocaleID) {
+        this.displayLocaleID = displayLocaleID;
     }
 }

--- a/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/dto/LocaleDataDTO.java
+++ b/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/dto/LocaleDataDTO.java
@@ -7,9 +7,6 @@ package com.vmware.i18n.dto;
 public class LocaleDataDTO {
     private String locale;
 
-    // Whether need to query default region based on language
-    private boolean pluralSearch = false;
-
     // Whether the LocaleID needs to be displayed
     private boolean displayLocaleID = true;
 
@@ -19,14 +16,6 @@ public class LocaleDataDTO {
 
     public void setLocale(String locale) {
         this.locale = locale;
-    }
-
-    public boolean isPluralSearch() {
-        return pluralSearch;
-    }
-
-    public void setPluralSearch(boolean pluralSearch) {
-        this.pluralSearch = pluralSearch;
     }
 
     public boolean isDisplayLocaleID() {

--- a/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/dto/LocaleDataDTO.java
+++ b/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/dto/LocaleDataDTO.java
@@ -10,6 +10,9 @@ public class LocaleDataDTO {
     // Whether the locale obtained by language+region is valid
     private boolean isInvalid = false;
 
+    // Whether the LocaleID needs to be displayed
+    private boolean isDisplay = true;
+
     public String getLocale() {
         return locale;
     }
@@ -24,5 +27,13 @@ public class LocaleDataDTO {
 
     public void setInvalid(boolean invalid) {
         isInvalid = invalid;
+    }
+
+    public boolean isDisplay() {
+        return isDisplay;
+    }
+
+    public void setDisplay(boolean display) {
+        isDisplay = display;
     }
 }

--- a/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/utils/CommonUtil.java
+++ b/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/utils/CommonUtil.java
@@ -130,6 +130,7 @@ public class CommonUtil {
         String locale = language + "-" + region;
         String cldrLocale = getCLDRLocale(locale, localePathMap, localeAliasesMap);
         if (!isEmpty(cldrLocale)) {
+            resultData.setInvalid(true);
             resultData.setLocale(cldrLocale);
             return resultData;
         }
@@ -181,6 +182,7 @@ public class CommonUtil {
             language = regionMap.get(region.toUpperCase());
             if (!CommonUtil.isEmpty(language)) {
                 locale = language + "-" + region;
+                resultData.setDisplay(false);
                 resultData.setInvalid(true);
             }
         }

--- a/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/utils/CommonUtil.java
+++ b/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/utils/CommonUtil.java
@@ -130,7 +130,7 @@ public class CommonUtil {
         String locale = language + "-" + region;
         String cldrLocale = getCLDRLocale(locale, localePathMap, localeAliasesMap);
         if (!isEmpty(cldrLocale)) {
-            resultData.setInvalid(true);
+            resultData.setPluralSearch(true);
             resultData.setLocale(cldrLocale);
             return resultData;
         }
@@ -182,8 +182,8 @@ public class CommonUtil {
             language = regionMap.get(region.toUpperCase());
             if (!CommonUtil.isEmpty(language)) {
                 locale = language + "-" + region;
-                resultData.setDisplay(false);
-                resultData.setInvalid(true);
+                resultData.setDisplayLocaleID(false);
+                resultData.setPluralSearch(true);
             }
         }
 

--- a/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/utils/CommonUtil.java
+++ b/g11n-ws/tools/tool-cldr-extractor/src/main/java/com/vmware/i18n/utils/CommonUtil.java
@@ -130,7 +130,6 @@ public class CommonUtil {
         String locale = language + "-" + region;
         String cldrLocale = getCLDRLocale(locale, localePathMap, localeAliasesMap);
         if (!isEmpty(cldrLocale)) {
-            resultData.setPluralSearch(true);
             resultData.setLocale(cldrLocale);
             return resultData;
         }
@@ -183,7 +182,6 @@ public class CommonUtil {
             if (!CommonUtil.isEmpty(language)) {
                 locale = language + "-" + region;
                 resultData.setDisplayLocaleID(false);
-                resultData.setPluralSearch(true);
             }
         }
 


### PR DESCRIPTION
https://github.com/vmware/singleton/issues/148: [Singleton Service][Get pattern by language&region] plurals rule should always follow with language
https://github.com/vmware/singleton/issues/149: [Singleton Service][Get pattern by locale] return default region when input is a language