### PR TITLE
Update the swagger-ui url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ To start using Singleton Service
  ```
  A user interface for testing all available API endpoints will be available in the following URL:
  ```
- https://localhost:8090/i18n/api/doc/swagger-ui
+ https://localhost:8090/i18n/api/doc/swagger-ui.html
  ```
  or
   ```
- http://localhost:8091/i18n/api/doc/swagger-ui
+ http://localhost:8091/i18n/api/doc/swagger-ui.html
  ```
  Sample translation resources will be in the following location:
  ```


### PR DESCRIPTION
Those 2 swagger-ui urls list in README show as blank page when try to open it.

Need to use a full url with .html.

This maybe caused by the swagger-ui upgrade.