### PR TITLE
Correct l10n data attribute naming.

### DIFF
--- a/samples/client/js/html/example.html
+++ b/samples/client/js/html/example.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title l10n="page.title"></title>
+    <title data-l10n-key="page.title"></title>
     <link
       href="https://fonts.googleapis.com/css?family=Lato:400,700"
       rel="stylesheet"
@@ -55,20 +55,20 @@
   <body>
     <div id="root">
       <header>
-        <h2 l10n="page.header"></h2>
+        <h2 data-l10n-key="page.header"></h2>
       </header>
 
       <section>
         <img class="main-image" alt="VMware logo" src="/assets/vmware.png" height="350px" width="500px"/>
 
-        <div class="main-info"><h3 class="main-label" l10n="page.main"></h3> <a href="https://github.com/vmware/singleton" l10n="page.link"></a></div>
+        <div class="main-info"><h3 class="main-label" data-l10n-key="page.main"></h3> <a href="https://github.com/vmware/singleton" data-l10n-key="page.link"></a></div>
       </section>
 
       <footer>
         <div>
-        <h6 l10n="page.footer"></h6>
+        <h6 data-l10n-key="page.footer"></h6>
         <div class="addition-info">
-          <span l10n="page.additional"></span>
+          <span data-l10n-key="page.additional"></span>
         </footer>
       </div>
       </footer>

--- a/samples/client/js/package.json
+++ b/samples/client/js/package.json
@@ -10,7 +10,7 @@
     "load-translation": "load-translation --directory `pwd`/src/sources --product CoreSDKClient --component ui --host http://localhost:8091 --version 1.0 --languages zh,en"
   },
   "dependencies": {
-    "@vip/vip-core-sdk": "file:../../vip-vip-core-sdk-0.1.0.tgz",
+    "@vip/vip-core-sdk": "file:../../../vip-vip-core-sdk-0.1.0.tgz",
     "argparse": "^1.0.10",
     "axios": "^0.19.0",
     "superagent": "^5.1.0",

--- a/samples/client/js/src/config.js
+++ b/samples/client/js/src/config.js
@@ -7,7 +7,7 @@ export const config = {
     // The language cookie name 
     langCookieName: 'vcs_locale',
     // The attribute in the DOM elements that holds the key for the translation.
-    localizeAttribute: 'l10n',
+    localizeAttribute: 'data-l10n-key',
     // The pseudo key for the localstorage 
     localStoragePseudoKey: 'enable_localization_pseudo'
 };


### PR DESCRIPTION
The attribute that holds the key for the translation is data attribute so it should follow the convention. 