### PR TITLE
use travis build matrix to test in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script: >
     cd $TRAVIS_BUILD_DIR/g11n-ws && ./gradlew jacocoTestReport sonarqube --stacktrace -Dsonar.login=$SONAR_TOKEN -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=$SONAR_ORG -Dsonar.projectKey=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -Dsonar.projectName=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -Dsonar.branch.name=master -Dsonar.coverage.exclusions=modules/**,tools/tool-trans-fetcher/src/**,vip-common/src/main/java/com/vmware/vip/common/**,vip-manager-l10n-agent/src/** --info
     echo $str Code Scan End $str
     git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.travis\.yml$' || {
-      echo "Only docs were updated, stopping build process."
+      echo "No need to check sonar quality gate for only travis configuration updates."
       exit
     }
     cd $TRAVIS_BUILD_DIR/devops/sonar && sleep 5 && python3 ./check_sonar_qualitygate.py -ProjectKeyPrefixArray=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -HostName=https://sonarcloud.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: trusty
 language: java
 python:
-  - "3.4"
+  - 3.4
 jdk:
   - openjdk8
-service:
+services:
   - docker
 before_install:
 - |
@@ -19,41 +19,52 @@ install:
   - sudo pip3 install requests
 jobs:
   include:
-    - stage: check header
-      script:
-        - git clone --branch=devops https://github.com/vmware/singleton.git devops && cp $TRAVIS_BUILD_DIR/devops/check_headers.py . && chmod +x check_headers.py
-        - python3 ./check_headers.py -f "$(git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE)"
-    - stage: unit test
-      script:
-        - cd $TRAVIS_BUILD_DIR/g11n-ws && ./gradlew test --console=plain
-    - stage: code scan
-      script:
-        - git clone --branch=devops https://github.com/vmware/singleton.git devops
-        - str=$(printf '=%.0s' {1..50})
-        - echo $str Code Scan Start $str
-        - cd $TRAVIS_BUILD_DIR/devops/sonar/ && python ./config_sonar_project.py -ProjectName=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -ProjectKey=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -OrgKey=$SONAR_ORG -QualityGateName=service-gate -QualityGateConditions="./quality_gates/service_quality_gate.json" -SonarToken=$SONAR_TOKEN
-        - cd $TRAVIS_BUILD_DIR/g11n-ws && sed -i "s/rootProject.name = 'vip'/rootProject.name = '$SONAR_ORG-singleton-service-$TRAVIS_BRANCH'/" settings.gradle && cat settings.gradle
-        - cd $TRAVIS_BUILD_DIR/g11n-ws && ./gradlew jacocoTestReport sonarqube --stacktrace -Dsonar.login=$SONAR_TOKEN -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=$SONAR_ORG -Dsonar.projectKey=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -Dsonar.projectName=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -Dsonar.branch.name=master -Dsonar.coverage.exclusions=modules/**,tools/tool-trans-fetcher/src/**,vip-common/src/main/java/com/vmware/vip/common/**,vip-manager-l10n-agent/src/** --info
-        - echo $str Code Scan End $str
-        - |
-            git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.travis\.yml$' || {
-              echo "Only docs were updated, stopping build process."
-              exit
-            }
-            cd $TRAVIS_BUILD_DIR/devops/sonar && sleep 5 && python3 ./check_sonar_qualitygate.py -ProjectKeyPrefixArray=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -HostName=https://sonarcloud.io
-    - stage: smoke test
-      script:
-        - git clone --branch=devops https://github.com/vmware/singleton.git devops
-        - cd $TRAVIS_BUILD_DIR/g11n-ws && ./gradlew build
-        - cp $TRAVIS_BUILD_DIR/devops/deploy/i18n-service/Dockerfile $TRAVIS_BUILD_DIR/publish/
-        - cd $TRAVIS_BUILD_DIR/publish && ls
-        - mv singleton-[0~9]*.jar i18n-service.jar && ls
-        - docker build -t singleton .
-        - docker run -d -p 8090:8090 --name singleton singleton
-        - docker ps
-        - cd $TRAVIS_BUILD_DIR/devops/autotest/service/i18n-service/APITest && gradle build
-        - docker cp l10n singleton:/
-        - str=$(printf '=%.0s' {1..50})
-        - echo $str Smoke Test Start $str
-        - java -cp "target/*:resource/*" org.testng.TestNG testng.xml
-        - echo $str Smoke Test End $str
+  - name: "Check Header"
+    env: TEST=check_header
+  - name: "Unit Test"
+    env: TEST=unit_test
+  - name: "Code Scan"
+    env: TEST=code_scan
+  - name: "Smoke Test"
+    env: TEST=smoke_test
+script: >
+  if [ x${TEST} = xcheck_header ]; then
+    git clone --branch=devops https://github.com/vmware/singleton.git devops
+    cp $TRAVIS_BUILD_DIR/devops/check_headers.py .
+    chmod +x check_headers.py
+    python3 ./check_headers.py -f "$(git diff --name-only --diff-filter=d $TRAVIS_COMMIT_RANGE)"
+  fi &&
+  if [ x${TEST} = xunit_test ]; then
+    cd $TRAVIS_BUILD_DIR/g11n-ws
+    ./gradlew test --console=plain
+  fi &&
+  if [ x${TEST} = xcode_scan ]; then
+    git clone --branch=devops https://github.com/vmware/singleton.git devops
+    str=$(printf '=%.0s' {1..50})
+    echo $str Code Scan Start $str
+    cd $TRAVIS_BUILD_DIR/devops/sonar/ && python ./config_sonar_project.py -ProjectName=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -ProjectKey=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -OrgKey=$SONAR_ORG -QualityGateName=service-gate -QualityGateConditions="./quality_gates/service_quality_gate.json" -SonarToken=$SONAR_TOKEN
+    cd $TRAVIS_BUILD_DIR/g11n-ws && sed -i "s/rootProject.name = 'vip'/rootProject.name = '$SONAR_ORG-singleton-service-$TRAVIS_BRANCH'/" settings.gradle && cat settings.gradle
+    cd $TRAVIS_BUILD_DIR/g11n-ws && ./gradlew jacocoTestReport sonarqube --stacktrace -Dsonar.login=$SONAR_TOKEN -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=$SONAR_ORG -Dsonar.projectKey=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -Dsonar.projectName=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -Dsonar.branch.name=master -Dsonar.coverage.exclusions=modules/**,tools/tool-trans-fetcher/src/**,vip-common/src/main/java/com/vmware/vip/common/**,vip-manager-l10n-agent/src/** --info
+    echo $str Code Scan End $str
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '\.travis\.yml$' || {
+      echo "Only docs were updated, stopping build process."
+      exit
+    }
+    cd $TRAVIS_BUILD_DIR/devops/sonar && sleep 5 && python3 ./check_sonar_qualitygate.py -ProjectKeyPrefixArray=$SONAR_ORG-singleton-service-$TRAVIS_BRANCH -HostName=https://sonarcloud.io
+  fi &&
+  if [ x${TEST} = xsmoke_test ]; then
+    git clone --branch=devops https://github.com/vmware/singleton.git devops
+    cd $TRAVIS_BUILD_DIR/g11n-ws && ./gradlew build
+    cp $TRAVIS_BUILD_DIR/devops/deploy/i18n-service/Dockerfile $TRAVIS_BUILD_DIR/publish/
+    cd $TRAVIS_BUILD_DIR/publish && ls
+    mv singleton-[0~9]*.jar i18n-service.jar && ls
+    docker build -t singleton .
+    docker run -d -p 8090:8090 --name singleton singleton
+    docker ps
+    cd $TRAVIS_BUILD_DIR/devops/autotest/service/i18n-service/APITest && gradle build
+    docker cp l10n singleton:/
+    str=$(printf '=%.0s' {1..50})
+    echo $str Smoke Test Start $str
+    java -cp "target/*:resource/*" org.testng.TestNG testng.xml
+    echo $str Smoke Test End $str
+  fi


### PR DESCRIPTION
execute following 4 tests parallel in separated environment:

1. check header
2. unit test
3. code scan
4. smoke test

Benefits:

1. less time cost(cut 70% time);
2. contributor can get all failures of all test in one time.(before, we use stages, the following stages will not be ran if current stage is failed)