### PR TITLE
G11n java client code clean up - remove logic of adding a cacheItem with an empty dataMap to cache for non-supported locales 

### DIFF
--- a/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
+++ b/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
@@ -102,19 +102,21 @@ public class ComponentService {
     	CacheService cacheService = new CacheService(dto);
     	MessageCacheItem cacheItem = cacheService.getCacheOfComponent();
     	if (cacheItem != null) { // Item is in cache
-    		if (cacheItem.getCachedData().isEmpty()) { // This means that the data to be used is from a fallback locale.
-				// If expired, try to first create and store cacheItem for the requested locale in a separate thread.
-				if (cacheItem.isExpired())
-					this.createCacheItemTask(null); // Pass null so that locale fallback will not be applied.
-
-    			// Use cached data of cacheItem.getLocale() --> fallback locale
-				MessagesDTO fallbackLocaleDTO = new MessagesDTO(dto.getComponent(), cacheItem.getLocale(), dto.getProductID(), dto.getVersion());
-				cacheItem = new ComponentService(fallbackLocaleDTO).getMessages(null);
-			} else if (cacheItem.isExpired()) {
+    		if (cacheItem.isExpired()) {
     			// Refresh the cacheItem in a separate thread
     			refreshCacheItemTask(cacheItem);
     		}
-    	} else { // Item is not in cache. Create and store cacheItem for the requested locale
+    	} else { // Item is not in cache.
+			ProductService ps = new ProductService(dto);
+			if (!ps.isSupportedLocale(Locale.forLanguageTag(dto.getLocale()))) { // Requested locale is not supported
+				Locale matchedLocale = LocaleUtility.pickupLocaleFromList(new LinkedList<>(ps.getSupportedLocales()), Locale.forLanguageTag(dto.getLocale()));
+				if (ps.isSupportedLocale(matchedLocale)) { // Requested locale matches a supported locale (eg. requested locale "fr_CA matches supported locale "fr")
+					MessagesDTO matchedLocaleDTO = new MessagesDTO(dto.getComponent(), matchedLocale.toLanguageTag(), dto.getProductID(), dto.getVersion());
+					return new ComponentService(matchedLocaleDTO).getMessages(null);
+				}
+			}
+
+			//Create and store cacheItem for the requested locale
 			cacheItem = createCacheItem(fallbackLocalesIter);
     	}
     	return cacheItem;
@@ -131,23 +133,6 @@ public class ComponentService {
 		// Create a new cacheItem object to be stored in cache
 		MessageCacheItem cacheItem = new MessageCacheItem();
 
-		// If the requested locale is not supported, but matches a supported locale (eg. requested locale "fr_CA matches supported locale "fr"),
-		// return the messages of the supported locale that best matches the requested locale.
-		ProductService ps = new ProductService(dto);
-		if (!ps.isSupportedLocale(Locale.forLanguageTag(dto.getLocale()))) {
-			Locale matchedLocale = LocaleUtility.pickupLocaleFromList(new LinkedList<>(ps.getSupportedLocales()), Locale.forLanguageTag(dto.getLocale()));
-			if (ps.isSupportedLocale(matchedLocale)) {
-				MessagesDTO matchedLocaleDTO = new MessagesDTO(dto.getComponent(), matchedLocale.toLanguageTag(), dto.getProductID(), dto.getVersion());
-				cacheItem = new ComponentService(matchedLocaleDTO).getMessages(null);
-				MessageCacheItem cacheItemCopy = new MessageCacheItem(matchedLocale.toLanguageTag(), null, null, System.currentTimeMillis(), cacheItem.getMaxAgeMillis());
-				cacheService.addCacheOfComponent(cacheItemCopy);
-				return cacheItem;
-			}
-		}
-
-		// Will proceed with the following code if
-		// a. requested locale is supported OR
-		// b. requested locale is not supported and does not match any supported locale
 		refreshCacheItem(cacheItem, VIPCfg.getInstance().getMsgOriginsQueue().iterator());
 		if (!cacheItem.getCachedData().isEmpty()) {
 			cacheService.addCacheOfComponent(cacheItem);
@@ -155,45 +140,18 @@ public class ComponentService {
 			// If failed to fetch message for the requested DTO, use MessageCacheItem of the next fallback locale.
 			MessagesDTO fallbackLocaleDTO = new MessagesDTO(dto.getComponent(), fallbackLocalesIter.next().toLanguageTag(), dto.getProductID(), dto.getVersion());
 			cacheItem = new ComponentService(fallbackLocaleDTO).getMessages(fallbackLocalesIter);
-			if (!cacheItem.getCachedData().isEmpty()) {
-				// Cache a copy of the fallback locale's cacheItem, but with only the locale and maxAgeMillis. Use current timestamp.
-				MessageCacheItem cacheItemCopy = new MessageCacheItem(cacheItem.getLocale(), null, null, System.currentTimeMillis(), cacheItem.getMaxAgeMillis());
-				cacheService.addCacheOfComponent(cacheItemCopy);
-			}
 		}
 
 		return cacheItem;
 	}
 
-	private void createCacheItemTask(Iterator<Locale> fallbackLocalesIter) {
-		Callable<MessageCacheItem> callable = () -> {
-			try {
-				return this.createCacheItem(fallbackLocalesIter);
-			} catch (Exception e) {
-				// To make sure that the thread will close
-				// even when an exception is thrown
-				return null;
-			}
-		};
-		FutureTask<MessageCacheItem> task = new FutureTask<>(callable);
-		Thread thread = new Thread(task);
-		thread.start();
-	}
-
 	private void refreshCacheItemTask(MessageCacheItem cacheItem) {
 		Callable<MessageCacheItem> callable = () -> {
     		try {
-    			// Get the locale of the cacheItem object. It may not be the same as the requested DTO's locale (e.g. the cacheItem is for a fallback locale).
-				String cacheItemLocale = cacheItem.getLocale();
-
-				// Refresh the properties of the cacheItem accordingly by passing a DTO with the correct locale
-				// to ComponentService, so that it will fetch messages for the correct locale to refresh the cacheItem.
-				MessagesDTO cacheItemDTO = new MessagesDTO(dto.getComponent(), cacheItemLocale, dto.getProductID(), dto.getVersion());
-				new ComponentService(cacheItemDTO).refreshCacheItem(cacheItem, VIPCfg.getInstance().getMsgOriginsQueue().listIterator());
-
+    			refreshCacheItem(cacheItem, VIPCfg.getInstance().getMsgOriginsQueue().listIterator());
 				return cacheItem;
-    		} catch (Exception e) { 
-    			// To make sure that the thread will close 
+    		} catch (Exception e) {
+    			// To make sure that the thread will close
     			// even when an exception is thrown
     			return null;
 		    }

--- a/src/main/java/com/vmware/vipclient/i18n/messages/service/ProductService.java
+++ b/src/main/java/com/vmware/vipclient/i18n/messages/service/ProductService.java
@@ -109,6 +109,7 @@ public class ProductService {
         return getSupportedLocales().contains(LocaleUtility.fmtToMappedLocale(locale));
     }
 
+
     private void refreshCacheItem(final MessageCacheItem cacheItem, DataSourceEnum dataSource) {
         long timestampOld = cacheItem.getTimestamp();
         dataSource.createProductOpt(dto).getSupportedLocales(cacheItem);
@@ -142,7 +143,6 @@ public class ProductService {
         }
         return null;
     }
-
     private Set<Locale> langTagtoLocaleSet (Set<String> languageTags) {
         Set<Locale> locales = new HashSet<>();
         if (languageTags != null) {

--- a/src/test/java/com/vmware/vip/i18n/SharedComponentTest.java
+++ b/src/test/java/com/vmware/vip/i18n/SharedComponentTest.java
@@ -75,12 +75,11 @@ public class SharedComponentTest extends BaseTestClass {
         Cache c = TranslationCacheManager.getCache(VIPCfg.CACHE_L3);
         Map<String, MessageCacheItem> m = ((MessageCache) c).getCachedTranslationMap();
         
-        Assert.assertTrue(m.size() == 3);
+
+        Assert.assertTrue(m.size() == 2);
         // TODO Null values are not allowed to be stored in the cache anymore. 
         // The following key must have non-null values to be stored. 
         //Assert.assertTrue(m.containsKey("JavaclientTest1_2.0.0_JSP_false_#de"));
-        
-        Assert.assertTrue(m.containsKey("JavaclientTest_1.0.0_JAVA_false_#zh"));
         Assert.assertTrue(m.containsKey("JavaclientTest_1.0.0_JAVA_false_#en"));
     }
 }

--- a/src/test/java/com/vmware/vip/i18n/SharedComponentTest.java
+++ b/src/test/java/com/vmware/vip/i18n/SharedComponentTest.java
@@ -74,7 +74,6 @@ public class SharedComponentTest extends BaseTestClass {
         VIPCfg gc = VIPCfg.getInstance();
         Cache c = TranslationCacheManager.getCache(VIPCfg.CACHE_L3);
         Map<String, MessageCacheItem> m = ((MessageCache) c).getCachedTranslationMap();
-        
 
         Assert.assertTrue(m.size() == 2);
         // TODO Null values are not allowed to be stored in the cache anymore. 

--- a/src/test/java/com/vmware/vipclient/i18n/messages/service/OfflineModeTest.java
+++ b/src/test/java/com/vmware/vipclient/i18n/messages/service/OfflineModeTest.java
@@ -22,6 +22,7 @@ import com.vmware.vipclient.i18n.messages.dto.BaseDTO;
 import com.vmware.vipclient.i18n.messages.dto.MessagesDTO;
 import com.vmware.vipclient.i18n.util.FormatUtils;
 import com.vmware.vipclient.i18n.util.LocaleUtility;
+import org.checkerframework.checker.formatter.FormatUtil;
 import org.json.simple.parser.ParseException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -91,15 +92,15 @@ public class OfflineModeTest extends BaseTestClass {
         
         dto.setProductID(VIPCfg.getInstance().getProductName());
         dto.setVersion(VIPCfg.getInstance().getVersion());
-        
-    	CacheService cs = new CacheService(dto);
-    	String message = translation.getMessage(locale, component, key, args);
-    	assertEquals(FormatUtils.format(messageFil, locale, args), message);
 
-        // cs.getCacheOfComponent() for fil-PH returns MessageCacheItem of fil
-        MessageCacheItem filPHCacheItem = cs.getCacheOfComponent();
-        Assert.assertTrue(filPHCacheItem.getLocale().equals("fil"));
-    	
+        // fil-PH cacheItem does not exist
+        CacheService cs = new CacheService(dto);
+        assertNull(cs.getCacheOfComponent());
+
+        // fil-PH matches fil cacheItem
+    	String messageFilPh = translation.getMessage(locale, component, key, args);
+    	assertEquals(FormatUtils.format(messageFil, locale, args), messageFilPh);
+
     	cfg.setOfflineResourcesBaseUrl(offlineResourcesBaseUrlOrig);
     	cfg.setMsgOriginsQueue(msgOriginsQueueOrig);
     }
@@ -179,11 +180,9 @@ public class OfflineModeTest extends BaseTestClass {
     	// Returns the message in the default locale
     	assertEquals(FormatUtils.format(source, args), message);
     	
-    	// cacheItem for "es" locale has an empty data map. It's locale is the fallback locale.
-    	MessageCacheItem cacheItem = cs.getCacheOfComponent();
-        assertEquals("en", cacheItem.getLocale());
-    	assertTrue(cacheItem.getCachedData().isEmpty());
-    	
+    	// There is no cacheItem  for "es" locale.
+        assertNull(cs.getCacheOfComponent());
+
     	cfg.setOfflineResourcesBaseUrl(offlineResourcesBaseUrlOrig);
     	cfg.setMsgOriginsQueue(msgOriginsQueueOrig);
     }
@@ -257,9 +256,10 @@ public class OfflineModeTest extends BaseTestClass {
     	
     	String message = translation.getMessage(locale, component, key, args);
     	assertEquals(FormatUtils.format(messageFil, locale, args), message);
-    	
-    	MessageCacheItem cacheItem = cs.getCacheOfComponent();
-    	assertEquals(messageFil, cacheItem.getCachedData().get(key));
+
+    	// fil-PH does not exist in cache
+    	//assertNull(cs.getCacheOfComponent());
+    	assertEquals(FormatUtils.format(messageFil, args), message);
     	
     	cfg.setOfflineResourcesBaseUrl(offlineResourcesBaseUrlOrig);
     	cfg.setMsgOriginsQueue(msgOriginsQueueOrig);
@@ -323,11 +323,13 @@ public class OfflineModeTest extends BaseTestClass {
 
         I18nFactory i18n = I18nFactory.getInstance(VIPCfg.getInstance());
         TranslationMessage translation = (TranslationMessage) i18n.getMessageInstance(TranslationMessage.class);
-        translation.getMessage(locale, component, key, args);
+        String messageFilPh = translation.getMessage(locale, component, key, args);
 
-        // cs.getCacheOfComponent() for fil-PH returns MessageCacheItem of fil
-        MessageCacheItem filPHCacheItem = cs.getCacheOfComponent();
-        Assert.assertTrue(filPHCacheItem.getLocale().equals("fil"));
+        // fil-PH cacheItem does not exist
+        assertNull(cs.getCacheOfComponent());
+
+        // fil-PH matches fil cacheItem
+        assertEquals(FormatUtils.format(messageFil, locale, args), messageFilPh);
 
         // Disable offline mode off for next tests.
         cfg.setOfflineResourcesBaseUrl(offlineResourcesBaseUrlOrig);
@@ -357,20 +359,16 @@ public class OfflineModeTest extends BaseTestClass {
         
     	CacheService cs = new CacheService(dto);
 
-    	translation.getMessage(newLocale, component, key, args);
+    	String message = translation.getMessage(newLocale, component, key, args);
     	
     	MessageCacheItem cacheItem = cs.getCacheOfComponent();
-    	assertNotNull(cacheItem);
+    	assertNull(cacheItem);
     	
     	MessagesDTO defaultLocaleDTO = new MessagesDTO(dto.getComponent(), 
 				dto.getKey(), dto.getSource(), LocaleUtility.getDefaultLocale().toLanguageTag(), null);
     	CacheService csDefault = new CacheService(defaultLocaleDTO);
-    	MessageCacheItem cacheItemDefaultLocale = csDefault.getCacheOfComponent();
-    	
-    	// cacheItem of Locale.ITALIAN's data map is empty. Its locale is the fallback locale
-    	assertTrue(cacheItem.getCachedData().isEmpty());
-        assertEquals("en", cacheItem.getLocale());
-    	
+        assertEquals(message, FormatUtils.format(csDefault.getCacheOfComponent().getCachedData().get(key), args));
+
     	cfg.setOfflineResourcesBaseUrl(offlineResourcesBaseUrlOrig);
     	cfg.setMsgOriginsQueue(msgOriginsQueueOrig);
     }


### PR DESCRIPTION
This is just the first step (code clean up) in solving 754. Here, I have removed the logic of adding a cacheItem with an empty dataMap to the cache for non-supported locales. We do not need this anymore because we are now first getting the list of supported locales to check if a locale is supported or not.

Next step is to use the fallback locale immediately to avoid fetch from service. This will be in another PR.