### PR TITLE
Fix for bug 812 G11n-java-client New workflow's Translation.getMessage must be able to use latest source messages from VIP service

### DIFF
--- a/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
+++ b/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
@@ -55,8 +55,8 @@ public class ComponentService {
 		long timestampOld = cacheItem.getTimestamp();
 		DataSourceEnum dataSource = msgSourceQueueIter.next();
 		String localeOrig = dto.getLocale();
-		if (dataSource.equals(DataSourceEnum.VIP) && dto.getLocale().equals("source")) {
-			dto.setLocale("latest");
+		if (dataSource.equals(DataSourceEnum.VIP) && dto.getLocale().equals(ConstantsKeys.SOURCE)) {
+			dto.setLocale(ConstantsKeys.LATEST);
 		}
 		dataSource.createMessageOpt(dto).getComponentMessages(cacheItem);
 		long timestamp = cacheItem.getTimestamp();
@@ -67,7 +67,7 @@ public class ComponentService {
 
 		// If timestamp is 0, it means that cacheItem not yet in cache. So try the next data source.
 		// If locale is "source", use messages from DatasourceEnum.Bundle data store if it exists.
-		if (timestamp == 0 || dto.getLocale().equals("source")) {
+		if (timestamp == 0 || dto.getLocale().equals(ConstantsKeys.SOURCE)) {
 			// Try the next dataSource in the queue
 			refreshCacheItem(cacheItem, msgSourceQueueIter);
 		}

--- a/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
+++ b/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
@@ -54,18 +54,24 @@ public class ComponentService {
 
 		long timestampOld = cacheItem.getTimestamp();
 		DataSourceEnum dataSource = msgSourceQueueIter.next();
+		String localeOrig = dto.getLocale();
+		if (dataSource.equals(DataSourceEnum.VIP) && dto.getLocale().equals("source")) {
+			dto.setLocale("latest");
+		}
 		dataSource.createMessageOpt(dto).getComponentMessages(cacheItem);
 		long timestamp = cacheItem.getTimestamp();
 		if (timestampOld == timestamp) {
 			logger.debug(FormatUtils.format(ConstantsMsg.GET_MESSAGES_FAILED, dto.getComponent(), dto.getLocale(), dataSource.toString()));
 		}
+		dto.setLocale(localeOrig);
 
-		// If timestamp is not 0, it means that cacheItem is in the cache already.
-		// Otherwise, try the next dataSource in the queue.
-		if (timestamp == 0) {
+		// If timestamp is 0, it means that cacheItem not yet in cache. So try the next data source.
+		// If locale is "source", use messages from DatasourceEnum.Bundle data store if it exists.
+		if (timestamp == 0 || dto.getLocale().equals("source")) {
 			// Try the next dataSource in the queue
 			refreshCacheItem(cacheItem, msgSourceQueueIter);
 		}
+
 	}
 
 	/**

--- a/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
+++ b/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
@@ -66,8 +66,7 @@ public class ComponentService {
 		dto.setLocale(localeOrig);
 
 		// If timestamp is 0, it means that cacheItem not yet in cache. So try the next data source.
-		// If locale is "source", use messages from DatasourceEnum.Bundle data store if it exists.
-		if (timestamp == 0 || dto.getLocale().equals(ConstantsKeys.SOURCE)) {
+		if (timestamp == 0)) {
 			// Try the next dataSource in the queue
 			refreshCacheItem(cacheItem, msgSourceQueueIter);
 		}

--- a/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
+++ b/src/main/java/com/vmware/vipclient/i18n/messages/service/ComponentService.java
@@ -66,7 +66,7 @@ public class ComponentService {
 		dto.setLocale(localeOrig);
 
 		// If timestamp is 0, it means that cacheItem not yet in cache. So try the next data source.
-		if (timestamp == 0)) {
+		if (timestamp == 0) {
 			// Try the next dataSource in the queue
 			refreshCacheItem(cacheItem, msgSourceQueueIter);
 		}

--- a/src/test/java/com/vmware/vip/i18n/HttpRequesterTest.java
+++ b/src/test/java/com/vmware/vip/i18n/HttpRequesterTest.java
@@ -52,6 +52,7 @@ public class HttpRequesterTest extends BaseTestClass {
     public void addHeaderParamsTest_() {
         String url = "/i18n/api/v2/translation/products/JavaclientTest/versions/1.0.0/locales/[^/]*?/components/default\\?pseudo=false";
         String url2 = "/i18n/api/v2/translation/products/JavaclientTest/versions/1.0.0/localelist";
+        String url3 = "/i18n/api/v2/translation/products/JavaclientTest/versions/1.0.0/locales/latest/components/default\\?pseudo=true";
 
         HashMap<String, String> params = new HashMap<>();
         String key1 = "key-1";
@@ -64,6 +65,7 @@ public class HttpRequesterTest extends BaseTestClass {
 
         WireMock.stubFor(WireMock.get(WireMock.urlMatching(url)).willReturn(WireMock.aResponse().withStatus(200)));
         WireMock.stubFor(WireMock.get(WireMock.urlMatching(url2)).willReturn(WireMock.aResponse().withStatus(200)));
+        WireMock.stubFor(WireMock.get(WireMock.urlMatching(url3)).willReturn(WireMock.aResponse().withStatus(200)));
 
         TranslationMessage tm = (TranslationMessage) I18nFactory.getInstance()
                 .getMessageInstance(TranslationMessage.class);
@@ -83,6 +85,7 @@ public class HttpRequesterTest extends BaseTestClass {
     public void addHeaderParamsTest() {
         String url = "/i18n/api/v2/translation/products/JavaclientTest/versions/1.0.0/locales/[^/]*?/components/default\\?pseudo=false";
         String url2 = "/i18n/api/v2/translation/products/JavaclientTest/versions/1.0.0/localelist";
+        String url3 = "/i18n/api/v2/translation/products/JavaclientTest/versions/1.0.0/locales/latest/components/default\\?pseudo=true";
 
         HashMap<String, String> params = new HashMap<>();
         String key1 = "key-1";
@@ -95,6 +98,7 @@ public class HttpRequesterTest extends BaseTestClass {
 
         WireMock.stubFor(WireMock.get(WireMock.urlMatching(url)).willReturn(WireMock.aResponse().withStatus(200)));
         WireMock.stubFor(WireMock.get(WireMock.urlMatching(url2)).willReturn(WireMock.aResponse().withStatus(200)));
+        WireMock.stubFor(WireMock.get(WireMock.urlMatching(url3)).willReturn(WireMock.aResponse().withStatus(200)));
 
         TranslationMessage tm = (TranslationMessage) I18nFactory.getInstance()
                 .getMessageInstance(TranslationMessage.class);


### PR DESCRIPTION
Fix for bug 812: G11n-java-client New workflow's Translation.getMessage must be able to fallback to "latest" messages from VIP service if messages_source.json is not present locally(offline) in the client