### PR TITLE
Code clean up - Do not use the singleton design pattern on VIPCfg

### DIFF
--- a/src/main/java/com/vmware/vipclient/i18n/VIPCfg.java
+++ b/src/main/java/com/vmware/vipclient/i18n/VIPCfg.java
@@ -35,8 +35,6 @@ public class VIPCfg {
     Logger                             logger        = LoggerFactory.getLogger(VIPCfg.class);
 
     // define global instance
-    private static VIPCfg              gcInstance;
-    private static Map<String, VIPCfg> moduleCfgs    = new HashMap<String, VIPCfg>();
     private VIPService                 vipService;
     private TranslationCacheManager    translationCacheManager;
 
@@ -79,34 +77,28 @@ public class VIPCfg {
 
     private boolean isSubInstance = false;
 
-    private VIPCfg() {
+    public VIPCfg() {
 
     }
 
     /**
-     * create a default instance of VIPCfg
-     * 
-     * @return
+     * @deprecated Use the {@link com.vmware.vipclient.i18n.VIPConfigs#getMainCfg() getMainCfg} method.
      */
-    public static synchronized VIPCfg getInstance() {
-        if (gcInstance == null) {
-            gcInstance = new VIPCfg();
-        }
-        return gcInstance;
+    public static VIPCfg getInstance() {
+        return VIPConfigs.getMainCfgInstance();
     }
 
     /**
-     * create a default instance of VIPCfg
-     *
-     * @return
+     * @deprecated Use the {@link com.vmware.vipclient.i18n.VIPConfigs#getCfg(String) getCfg} method.
      */
     public static synchronized VIPCfg getSubInstance(String productName) {
-        if (!VIPCfg.moduleCfgs.containsKey(productName)) {
+        if (!VIPConfigs.contains(productName)) {
             VIPCfg cfg = new VIPCfg();
             cfg.isSubInstance = true;
-            VIPCfg.moduleCfgs.put(productName, cfg);
+            cfg.setProductName(productName);
+            VIPConfigs.addCfg(cfg);
         }
-        return VIPCfg.moduleCfgs.get(productName);
+        return VIPConfigs.getCfg(productName);
     }
 
     /**
@@ -135,7 +127,7 @@ public class VIPCfg {
 
         if (prop.containsKey("productName"))
             this.setProductName(prop.getString("productName"));
-        if (this.isSubInstance() && !VIPCfg.moduleCfgs.containsKey(this.productName)) {
+        if (this.isSubInstance() && !VIPConfigs.contains(this.productName)) {
             throw new VIPClientInitException(
                     "Can't not initialize sub VIPCfg instance, the product name is not defined in config file.");
         }

--- a/src/main/java/com/vmware/vipclient/i18n/VIPConfigs.java
+++ b/src/main/java/com/vmware/vipclient/i18n/VIPConfigs.java
@@ -1,0 +1,33 @@
+package com.vmware.vipclient.i18n;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class VIPConfigs {
+    private static final Map<String, VIPCfg> configs = new HashMap<>();
+    private static VIPCfg mainCfg;
+
+    public static VIPCfg getMainCfg() {
+        return mainCfg;
+    }
+
+    public static synchronized VIPCfg getMainCfgInstance() {
+        if (getMainCfg() == null) {
+            mainCfg = new VIPCfg();
+        }
+        return VIPConfigs.getMainCfg();
+    }
+
+    public static VIPCfg getCfg(String productName) {
+        return configs.get(productName);
+    }
+
+    public static void addCfg(VIPCfg cfg) {
+        configs.put(cfg.getProductName(), cfg);
+    }
+
+    public static boolean contains(String productName) {
+        return configs.containsKey(productName);
+    }
+
+}


### PR DESCRIPTION
VIPCfg.java was originally using the Singleton design pattern (single static VIPCfg object instance for the entire application). However, the use case of having multiple VIP products in the same app was introduced (a.k.a subInstance). The singleton design pattern is not applicable in this anymore as multiple instances of VIPCfg have to be created and stored.

Solution:
1. Remove the static "gcInstance" from VIPCfg. Store it in VIPConfigs.java.
2. Remove moduleCfgs from VIPCfg. Store it in VIPConfigs.java.