### PR TITLE
To correctly get source from remote when a new component is provided …

### DIFF
--- a/sgtn4python/sgtn_client.py
+++ b/sgtn4python/sgtn_client.py
@@ -477,6 +477,11 @@ class SingletonRelease(Release, Translation):
         if not source:
             if component in self.source:
                 source = self.source[component].messages.get(key)
+            else:
+                remote_source = self._get_remote_resource(self.cfg.source_locale, component)
+                if remote_source:
+                    self.source[component] = remote_source
+                    source = self.source[component].messages.get(key)
 
         text = self._get_message(component, key, source, locale)
         if text and items:


### PR DESCRIPTION
…in service