### PR TITLE
PR1 of issue 990: [Java Client] Default to depend on English i18n formatting pattern in Java client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ description = 'VIP i18n pattern CLDR data extract tools'
 ext {
     javaLevel = 1.8
     cldrVersion = '32.0.0'
-    projectVersion = '0.10.38'
+    projectVersion = '0.11.0'
     deployPath="$rootDir/../publish/"
     sourceCompatibility = javaLevel
     version = '1.0'
@@ -43,7 +43,7 @@ jar {
     baseName = "i18n-patterns-core"
     version = "$projectVersion"
     classifier = ''
-    exclude('**/cldr/data/*')
+    exclude('**/cldr/data','**/cldr/pattern/**','**/cldr/localedata/**','**/cldr/misc/**')
 }
 
 repositories {
@@ -72,21 +72,46 @@ jacocoTestReport {
     }
 }
 
-task copyResources(type: Copy) {
-	File dir = new File("${buildDir}/classes/main");
-	dir.deleteDir();
-	from "${projectDir}/src/main/resources"
-    into "${buildDir}/classes/main"
+task download(type: JavaExec, dependsOn: classes){
+    main 'com.vmware.i18n.PatternParseMain'
+    classpath sourceSets.main.runtimeClasspath
+}
+
+task copyResources(type: Copy, dependsOn: download) {
+    File dir = new File("${buildDir}/resources/main");
+    dir.deleteDir();
     from "${projectDir}/src/main/resources"
     into "${buildDir}/resources/main"
 }
 
-processTestResources.dependsOn copyResources
+task generateBundleZip(type: Zip, dependsOn: copyResources){
+    archiveBaseName='cldr'
+    archiveVersion = "$projectVersion"
+    from "${buildDir}/resources/main/cldr"
+    includes =['pattern/**','localedata/**','misc/**']
+    into "cldr"
+    //destinationDir file("$rootDir/../publish/")
 
-task download(type: JavaExec, dependsOn: classes){
-	main 'com.vmware.i18n.PatternParseMain'
-	classpath sourceSets.main.runtimeClasspath
 }
 
-copyResources.dependsOn download
-//assemble.dependsOn.add copyLibs
+task generateEnZip(type: Zip, dependsOn: copyResources){
+    archiveBaseName='cldr-en'
+    archiveVersion = "$projectVersion"
+    from "${buildDir}/resources/main/cldr"
+    includes =['pattern/common/en/**','pattern/timezone/en/**','localedata/en/**','misc/en/**']
+    into "cldr"
+    //destinationDir file("$rootDir/../publish/")
+
+}
+
+task copyLibs(type :Copy, dependsOn: [jar, generateBundleZip, generateEnZip]) {
+    from "$buildDir/libs", "$buildDir/distributions"
+    into "$rootDir/publish/"
+    println "The build was output to -> $rootDir/publish/"
+    include "**/*.jar", "**/*.zip"
+}
+
+
+
+
+assemble.dependsOn.add copyLibs

--- a/src/main/java/com/vmware/i18n/PatternConfig.java
+++ b/src/main/java/com/vmware/i18n/PatternConfig.java
@@ -1,5 +1,12 @@
+/*
+ * Copyright 2019-2021 VMware, Inc.
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package com.vmware.i18n;
 
+/**
+ * Singleton class for store the path of pattern bundle
+ */
 public class PatternConfig {
     private static volatile PatternConfig instance = null;
     private String patternPath;

--- a/src/main/java/com/vmware/i18n/PatternConfig.java
+++ b/src/main/java/com/vmware/i18n/PatternConfig.java
@@ -1,0 +1,28 @@
+package com.vmware.i18n;
+
+public class PatternConfig {
+    private static volatile PatternConfig instance = null;
+    private String patternPath;
+
+    private PatternConfig() {
+    }
+
+    public static PatternConfig getInstance() {
+        if (null == instance) {
+            synchronized (PatternConfig.class) {
+                if (null == instance) {
+                    instance = new PatternConfig();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public String getPatternPath() {
+        return patternPath;
+    }
+
+    public void setPatternPath(String patternPath) {
+        this.patternPath = patternPath;
+    }
+}

--- a/src/main/java/com/vmware/i18n/common/CLDRConstants.java
+++ b/src/main/java/com/vmware/i18n/common/CLDRConstants.java
@@ -47,8 +47,8 @@ public class CLDRConstants {
 	// cldr
 	public static final String JSON_PATH = CLDRConstants.class.getProtectionDomain().getCodeSource().getLocation()
 			.getPath();
-	public static final String RESOURCES_PATH = CLDRConstants.class.getResource("/cldr").getPath() + "/../";
-	public static final String PARSE_DATA = "cldr/pattern/common/parse.json";
+	public static final String RESOURCES_PATH = CLDRConstants.class.getClassLoader().getResource("cldr").getPath() + "/../";
+	public static final String PARSE_DATA = "cldr/core/parse.json";
 	public static final String PATTERN_JSON_PATH = "cldr/pattern/common/{0}/pattern.json";
 	public static final String SUPPLEMENTAL_PATH = "cldr/supplement/{0}.json";
 	public static final String ALL_CATEGORIES = "dates,numbers,plurals,measurements,currencies,dateFields";

--- a/src/main/java/com/vmware/i18n/locale/service/impl/LocaleServiceImpl.java
+++ b/src/main/java/com/vmware/i18n/locale/service/impl/LocaleServiceImpl.java
@@ -4,19 +4,20 @@
  */
 package com.vmware.i18n.locale.service.impl;
 
-import java.text.MessageFormat;
-import java.util.Map;
-
 import com.vmware.i18n.common.CLDRConstants;
 import com.vmware.i18n.common.Constants;
 import com.vmware.i18n.locale.dao.impl.LocaleDaoImpl;
 import com.vmware.i18n.locale.service.ILocaleService;
 import com.vmware.i18n.utils.JSONUtil;
 import com.vmware.i18n.utils.LocalJSONReader;
+import com.vmware.i18n.utils.PathUtils;
+
+import java.text.MessageFormat;
+import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class LocaleServiceImpl implements ILocaleService {
-
+	private String resourcePath = PathUtils.getResourcePath();
 	public static Map<String, String> localePathMap = null;
 	public static Map<String, String> defaultContentMap = null;
 	static {
@@ -38,7 +39,7 @@ public class LocaleServiceImpl implements ILocaleService {
 		if (localePathMap.get(language) == null)
 			return "";
 		filePath = MessageFormat.format(filePath, localePathMap.get(language));
-		return new LocaleDaoImpl().getLocaleData(CLDRConstants.JSON_PATH, filePath);
+		return new LocaleDaoImpl().getLocaleData(resourcePath, filePath);
 	}
 
 	/**
@@ -66,7 +67,7 @@ public class LocaleServiceImpl implements ILocaleService {
 		if (localePathMap.get(displayLanguage) == null)
 			return "";
 		String filePath = MessageFormat.format(CLDRConstants.CONTEXT_TRANSFORM_PATH, localePathMap.get(displayLanguage));
-		return new LocaleDaoImpl().getLocaleData(CLDRConstants.JSON_PATH, filePath);
+		return new LocaleDaoImpl().getLocaleData(resourcePath, filePath);
 	}
 
 }

--- a/src/main/java/com/vmware/i18n/pattern/service/impl/PatternServiceImpl.java
+++ b/src/main/java/com/vmware/i18n/pattern/service/impl/PatternServiceImpl.java
@@ -4,17 +4,6 @@
  */
 package com.vmware.i18n.pattern.service.impl;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +15,18 @@ import com.vmware.i18n.pattern.service.IPatternService;
 import com.vmware.i18n.utils.CommonUtil;
 import com.vmware.i18n.utils.JSONUtil;
 import com.vmware.i18n.utils.LocalJSONReader;
+import com.vmware.i18n.utils.PathUtils;
 import com.vmware.i18n.utils.timezone.TimeZoneName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("unchecked")
 public class PatternServiceImpl implements IPatternService {
@@ -137,14 +137,11 @@ public class PatternServiceImpl implements IPatternService {
 		IPatternDao dao = new PatternDaoImpl();
 		String[] cateList = categories.split(",");
 
-		String resourcePath = CLDRConstants.RESOURCES_PATH;
-		if (CLDRConstants.JSON_PATH.lastIndexOf(".jar") > 0) {
-			resourcePath = CLDRConstants.JSON_PATH;
-		}
+		String resourcePath = PathUtils.getResourcePath();
 
 		for (String cat : cateList) {
 			String filePath = MessageFormat.format(CLDRConstants.SUPPLEMENTAL_PATH, cat);
-			String suppleData = dao.getPattern(resourcePath, filePath);
+			String suppleData = dao.getPattern(PathUtils.getCoreResourcePath(), filePath);
 			if (!CommonUtil.isEmpty(suppleData)) {
 				suppleMap.put(cat, JSONUtil.string2SortMap(suppleData));
 			}
@@ -192,7 +189,7 @@ public class PatternServiceImpl implements IPatternService {
 		String pathLocale = CommonUtil.getPathLocale(tmpLocale, localePathMap, likelySubtagMap);
 		if (CommonUtil.isEmpty(pathLocale))
 			return null;
-		String patternStr = dao.getPattern(CLDRConstants.JSON_PATH,
+		String patternStr = dao.getPattern(PathUtils.getResourcePath(),
 				MessageFormat.format(CLDRConstants.DATE_TIMEZONENAME_JSON_PATH, pathLocale));
 		TimeZoneName timeZoneObj = null;
 		try {

--- a/src/main/java/com/vmware/i18n/utils/CLDRUtils.java
+++ b/src/main/java/com/vmware/i18n/utils/CLDRUtils.java
@@ -43,28 +43,26 @@ public class CLDRUtils {
 
 	private static Logger logger = LoggerFactory.getLogger(CLDRUtils.class);
 
-	public static final String CONFIG_PATH = "src" + File.separator + "main" + File.separator + "resources"
-			+ File.separator + "config.properties";
-	public static final Properties PROP = PropertiesFileUtil.loadFromFile(CONFIG_PATH);
-	public static final String CLDR_VERSION = PROP.getProperty("cldr.version");
-	public static final String CLDR_URLS = PROP.getProperty("cldr.urls");
-	public static final String CLDR_ADDITIONAL_CONFIG = PROP.getProperty("cldr.additional.config");
-	public static final String FILE_NAME = CLDR_VERSION + ".zip";
-	public static final String CLDR_DOWNLOAD_DIR = "src" + File.separator + "main" + File.separator + "resources"
-			+ File.separator + "cldr" + File.separator + "data" + File.separator + CLDR_VERSION + File.separator;
-	public static final String GEN_CLDR_PATTERN_DIR = "src" + File.separator + "main" + File.separator + "resources"
-			+ File.separator + "cldr" + File.separator + "pattern" + File.separator + "common" + File.separator;
-	public static final String GEN_CLDR_LOCALEDATA_DIR = "src" + File.separator + "main" + File.separator + "resources"
-			+ File.separator + "cldr" + File.separator + "localedata" + File.separator;
-	public static final String GEN_CLDR_PATTERN_TIMEZONE_DIR = "src" + File.separator + "main" + File.separator
-			+ "resources" + File.separator + "cldr" + File.separator + "pattern" + File.separator + "timezone"
-			+ File.separator;
+    public static final String RESOURCE_PATH = "src" + File.separator + "main" + File.separator + "resources";
+    public static final String CONFIG_PATH = RESOURCE_PATH + File.separator + "config.properties";
+    public static final Properties PROP = PropertiesFileUtil.loadFromFile(CONFIG_PATH);
+    public static final String CLDR_VERSION = PROP.getProperty("cldr.version");
+    public static final String CLDR_URLS = PROP.getProperty("cldr.urls");
+    public static final String CLDR_ADDITIONAL_CONFIG = PROP.getProperty("cldr.additional.config");
+    public static final String FILE_NAME = CLDR_VERSION + ".zip";
+    public static final String CLDR_PATH = RESOURCE_PATH + File.separator + "cldr" + File.separator;
+    public static final String CLDR_DOWNLOAD_DIR = CLDR_PATH + "data" + File.separator + CLDR_VERSION + File.separator;
+    public static final String GEN_CLDR_CORE_DIR = CLDR_PATH + "core" + File.separator;
+    public static final String GEN_CLDR_PATTERN_BASE_PATH = CLDR_PATH + "pattern" + File.separator;
+    public static final String GEN_CLDR_PATTERN_DIR = GEN_CLDR_PATTERN_BASE_PATH + "common" + File.separator;
+    public static final String GEN_CLDR_LOCALEDATA_DIR = CLDR_PATH + "localedata" + File.separator;
+    public static final String GEN_CLDR_PATTERN_TIMEZONE_DIR = GEN_CLDR_PATTERN_BASE_PATH + "timezone" + File.separator;
 
-	/**
-	 * Download CLDR data
-	 *
-	 * @return a map collection, store the zip file name and save path
-	 */
+    /**
+     * Download CLDR data
+     *
+     * @return a map collection, store the zip file name and save path
+     */
 	public static void download() {
 		int byteread = 0;
 		InputStream is = null;
@@ -92,12 +90,12 @@ public class CLDRUtils {
 					}
 				}
 				try {
-				fs = new FileOutputStream(CLDR_DOWNLOAD_DIR + fileName);
-				byte[] buffer = new byte[2048];
-				while ((byteread = is.read(buffer)) != -1) {
-					fs.write(buffer, 0, byteread);
-				}
-				fs.flush();
+					fs = new FileOutputStream(CLDR_DOWNLOAD_DIR + fileName);
+					byte[] buffer = new byte[2048];
+					while ((byteread = is.read(buffer)) != -1) {
+						fs.write(buffer, 0, byteread);
+					}
+					fs.flush();
 				}finally {
 					if(fs != null) {
 						fs.close();
@@ -966,13 +964,13 @@ public class CLDRUtils {
 		}
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private static void dataRecordForParse(Map<String, Object> likelySubtagMap, Map<String, String> recordMap) {
-		Map<String, Object> map = new TreeMap();
-		map.put("likelySubtag", new TreeMap(likelySubtagMap));
-		map.put("localePath", new TreeMap(recordMap));
-		writePatternDataIntoFile(GEN_CLDR_PATTERN_DIR + "parse.json", map);
-	}
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static void dataRecordForParse(Map<String, Object> likelySubtagMap, Map<String, String> recordMap) {
+        Map<String, Object> map = new TreeMap();
+        map.put("likelySubtag", new TreeMap(likelySubtagMap));
+        map.put("localePath", new TreeMap(recordMap));
+        writePatternDataIntoFile(GEN_CLDR_CORE_DIR + "parse.json", map);
+    }
 
 	public static void patternDataExtract() {
 		logger.info("Start to extract i18n pattern data ... ");

--- a/src/main/java/com/vmware/i18n/utils/PathUtils.java
+++ b/src/main/java/com/vmware/i18n/utils/PathUtils.java
@@ -1,0 +1,26 @@
+package com.vmware.i18n.utils;
+
+import com.vmware.i18n.PatternConfig;
+import com.vmware.i18n.common.CLDRConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PathUtils {
+    private static Logger logger = LoggerFactory.getLogger(PathUtils.class);
+
+    public static String getResourcePath() {
+        String resourcePath = CLDRConstants.RESOURCES_PATH; //this is the resource path when debug source code in IDE
+        if (PatternConfig.getInstance().getPatternPath() != null) {
+            resourcePath = PatternConfig.getInstance().getPatternPath(); //this is the configed resource path when format bundles are unbinded with source code
+        }
+        return resourcePath;
+    }
+
+    public static String getCoreResourcePath(){
+        String resourcePath = CLDRConstants.RESOURCES_PATH; //this is the resource path when debug source code in IDE
+        if (CLDRConstants.JSON_PATH.lastIndexOf(".jar") > 0) {
+            resourcePath = CLDRConstants.JSON_PATH; //this is the resource path when format bundles are binded with source code
+        }
+        return resourcePath;
+    }
+}

--- a/src/main/java/com/vmware/i18n/utils/PathUtils.java
+++ b/src/main/java/com/vmware/i18n/utils/PathUtils.java
@@ -1,12 +1,13 @@
+/*
+ * Copyright 2019-2021 VMware, Inc.
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package com.vmware.i18n.utils;
 
 import com.vmware.i18n.PatternConfig;
 import com.vmware.i18n.common.CLDRConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PathUtils {
-    private static Logger logger = LoggerFactory.getLogger(PathUtils.class);
 
     public static String getResourcePath() {
         String resourcePath = CLDRConstants.RESOURCES_PATH; //this is the resource path when debug source code in IDE

--- a/src/test/java/com/vmware/i18n/PatternUtilTest.java
+++ b/src/test/java/com/vmware/i18n/PatternUtilTest.java
@@ -4,10 +4,8 @@
  */
 package com.vmware.i18n;
 
-import com.vmware.i18n.pattern.action.PatternAction;
 import com.vmware.i18n.utils.JSONUtil;
 import com.vmware.i18n.utils.timezone.TimeZoneName;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,8 +32,7 @@ public class PatternUtilTest {
 	public void testGetPatternAPI() {
     	String locale = "fr";
 		String cateStr= "dates,numbers,plurals";
-		PatternAction pa = PatternAction.getInstance();
-		String json = pa.getPattern(locale, cateStr);
+		String json = PatternUtil.getPatternFromLib(locale, cateStr);
 		Map<String, Object> patternMap = (Map<String, Object>) JSONUtil.getMapFromJson(json);
 		Map<String, Object> catesMap = (Map<String, Object>) patternMap.get("categories");
 		String[] catesArr = cateStr.split(",");
@@ -48,7 +45,26 @@ public class PatternUtilTest {
 	@Test
 	public void testtimezoneListAPI() {
     	String locale = "fr";
-    	PatternAction pa = PatternAction.getInstance();
-    	TimeZoneName json = pa.getTimeZoneName(locale, true);
+    	TimeZoneName json = PatternUtil.getTimeZoneName(locale, true);
+		Assert.assertEquals("fr", json.getLanguage());
+		Assert.assertNotNull(json.getTimeZoneNames());
     }
+
+	@Test
+	public void testGetLanguageFromLib() {
+		String locale = "en";
+		String json = PatternUtil.getLanguageFromLib(locale);
+		Map<String, Object> languagesMap = (Map<String, Object>) JSONUtil.getMapFromJson(json);
+		Assert.assertEquals("en", languagesMap.get("displayLanguage"));
+		Assert.assertNotNull(languagesMap.get("languages"));
+	}
+
+	@Test
+	public void testGetContextTransformFromLib() {
+		String locale = "en";
+		String json = PatternUtil.getContextTransformFromLib(locale);
+		Map<String, Object> contextTransformsMap = (Map<String, Object>) JSONUtil.getMapFromJson(json);
+		Assert.assertEquals("en", contextTransformsMap.get("languages"));
+		Assert.assertNotNull(contextTransformsMap.get("contextTransforms"));
+	}
 }


### PR DESCRIPTION
1. change build script of tool-cldr-extractor project to build out zip package of l2 data and new jar package without l2 data
2. change code in tool-cldr-extractor project to make it be able to read l2 bundle from
     p1: configed path outside singleton service jar
     p2: bundle inside singleton service jar