### PR TITLE
Upgrade log4j to 2.15.0

### DIFF
--- a/g11n-ws/build.gradle
+++ b/g11n-ws/build.gradle
@@ -37,7 +37,7 @@ ext {
     snakeyam="1.29"
     jjwt="0.9.1"
     hibernateJpa21Api = "1.0.2"
-    log4j2Version="2.14.1"
+    log4j2Version="2.15.0"
     slf4jVersion="1.7.31"
     buildRelease = 'beta'
     remoteServer = ""


### PR DESCRIPTION
Background: A CVE in Log4J has recently been found. For reference on the said CVE: https://logging.apache.org/log4j/2.x/security.html

Changes: Upgrade the Log4J version to 2.15.0