### PR TITLE
update the smoke test code beacuse pr 1495 and 1496

### DIFF
--- a/autotest/client/ruby/spec/Default_cache_spec.rb
+++ b/autotest/client/ruby/spec/Default_cache_spec.rb
@@ -14,21 +14,21 @@ describe "Translation test" do
         end
 
         it "default_language is en and loadbundle is default.yml" do
-            SgtnClient.load("./config/sgtnclient.yml", "test")
+            SgtnClient.load("./config/sgtnclient.yml", "testsourcelocale1")
             SgtnClient::Source.loadBundles("default")
             expect(SgtnClient::Translation.getString("abou34324t", "about.message", "de")).to eq(nil)
             expect(SgtnClient::Translation.getString("about43242", "about.key3", "de")).to eq(nil)          
         end
 
         it "default_language is zh-Hans and loadbundle is default.yml" do
-            SgtnClient.load("./config/sgtnclient.yml", "test")
+            SgtnClient.load("./config/sgtnclient.yml", "testsourcelocale2")
             SgtnClient::Source.loadBundles("default")
             expect(SgtnClient::Translation.getString_f("about32", "about.test123",["a1","a2","a3"], "de")).to eq(nil)
         end
 
         
         it "default_language is da and loadbundle is default.yml" do
-            SgtnClient.load("./config/sgtnclient.yml", "test")
+            SgtnClient.load("./config/sgtnclient.yml", "testsourcelocale3")
             SgtnClient::Source.loadBundles("default")
             puts SgtnClient::Translation.getStrings("about12", "en-US")
         end

--- a/autotest/client/ruby/spec/SimpleT_offline_spec.rb
+++ b/autotest/client/ruby/spec/SimpleT_offline_spec.rb
@@ -94,7 +94,17 @@ describe "Translation test" do
         it "Get a string's translation and locale argument type is incorrect" do
             RequestStore.store[:locale] = 123
             RequestStore.store[:component] = 'about'
-            expect{SgtnClient::T.s("about.message")}.to raise_error(NoMethodError)
+            #puts SgtnClient::T.s("about.message")
+            expect(SgtnClient::T.s("about.message")).to eq("fall back about")
+            #expect{SgtnClient::T.s("about.message")}.to raise_error(NoMethodError)
+        end
+
+        it "Get a string's translation and locale argument type is nil" do
+            RequestStore.store[:locale] = nil
+            RequestStore.store[:component] = 'about'
+            #puts SgtnClient::T.s("about.message")
+            expect(SgtnClient::T.s("about.message")).to eq("fall back about")
+            #expect{SgtnClient::T.s("about.message")}.to raise_error(NoMethodError)
         end
 
         # it "Get a string's translation and key type is incorrect" do
@@ -235,7 +245,8 @@ describe "Translation test" do
         it "Get a component's translations and locale type is incorrect" do
             RequestStore.store[:locale] = 123
             RequestStore.store[:component] = 'about'
-            expect{SgtnClient::T.c()}.to raise_error(NoMethodError)
+            expect(SgtnClient::T.c()["messages"]["about.key3"]).to eq("fall back key31")
+            #expect{SgtnClient::T.c()}.to raise_error(NoMethodError)
             ##puts SgtnClient::T.c("about", "zh-CN")
         end
 

--- a/autotest/client/ruby/spec/SimpleT_spec .rb
+++ b/autotest/client/ruby/spec/SimpleT_spec .rb
@@ -46,7 +46,7 @@ describe "Translation test" do
         end
 
         it "Get a string's translation and locale not exist in server" do
-            RequestStore.store[:locale] = 'da'
+            RequestStore.store[:locale] = "da"
             RequestStore.store[:component] = 'about'
             #SgtnClient::Source.loadBundles("en")
             expect(SgtnClient::T.s("about.message")).to eq("fall back about")
@@ -84,7 +84,15 @@ describe "Translation test" do
         it "Get a string's translation and locale argument type is incorrect" do
             RequestStore.store[:locale] = 123
             RequestStore.store[:component] = 'about'
-            expect{SgtnClient::T.s("about.message")}.to raise_error(NoMethodError)
+            expect(SgtnClient::T.s("about.message")).to eq("fall back about")
+            #expect{SgtnClient::T.s("about.message")}.to raise_error(NoMethodError)
+        end
+
+        it "Get a string's translation and locale argument type is nil" do
+            RequestStore.store[:locale] = nil
+            RequestStore.store[:component] = 'about'
+            expect(SgtnClient::T.s("about.message")).to eq("fall back about")
+            #expect{SgtnClient::T.s("about.message")}.to raise_error(NoMethodError)
         end
 
         # it "Get a string's translation and key type is incorrect" do
@@ -225,7 +233,8 @@ describe "Translation test" do
         it "Get a component's translations and locale type is incorrect" do
             RequestStore.store[:locale] = 123
             RequestStore.store[:component] = 'about'
-            expect{SgtnClient::T.c()}.to raise_error(NoMethodError)
+            expect(SgtnClient::T.c()["messages"]["about.key3"]).to eq("fall back key31")
+            #expect{SgtnClient::T.c()}.to raise_error(NoMethodError)
             ##puts SgtnClient::T.c("about", "zh-CN")
         end
 

--- a/autotest/client/ruby/spec/Translation_offline_spec.rb
+++ b/autotest/client/ruby/spec/Translation_offline_spec.rb
@@ -25,9 +25,9 @@ describe "Translation test" do
             expect(SgtnClient::Translation.getString("about", "about.message", "en")).to eq("fall back about")
         end
 
-        it "Get a string's translation and locale is fr-FR" do
+        it "Get a string's translation and locale is fr" do
             #SgtnClient::Source.loadBundles("de")
-            expect(SgtnClient::Translation.getString("about", "about.message", "fr-FR")).to eq("test fr offline key")
+            expect(SgtnClient::Translation.getString("about", "about.message", :fr)).to eq("test fr offline key")
         end
 
         it "Get a string's translation and locale is zh-Hans-CN" do
@@ -61,7 +61,13 @@ describe "Translation test" do
 
 
         it "Get a string's translation and locale argument type is incorrect" do
-            expect{SgtnClient::Translation.getString("about", "about.message", 123)}.to raise_error(NoMethodError)
+            #expect{SgtnClient::Translation.getString("about", "about.message", 123)}.to raise_error(NoMethodError)
+            expect(SgtnClient::Translation.getString("about", "about.message", 123)).to eq("fall back about")
+        end
+
+        it "Get a string's translation and locale argument type is nil" do
+            #expect{SgtnClient::Translation.getString("about", "about.message", 123)}.to raise_error(NoMethodError)
+            expect(SgtnClient::Translation.getString("about", "about.message", nil)).to eq("fall back about")
         end
 
         # it "Get a string's translation and key type is incorrect" do
@@ -162,7 +168,14 @@ describe "Translation test" do
         end
 
         it "Get a component's translations and locale type is incorrect" do
-            expect{SgtnClient::Translation.getStrings("about", 123)}.to raise_error(NoMethodError)
+            #expect{SgtnClient::Translation.getStrings("about", 123)}.to raise_error(NoMethodError)
+            expect(SgtnClient::Translation.getStrings("about", 123)["messages"]["about.message"]).to eq("fall back about")
+            ##puts SgtnClient::Translation.getStrings("about", "zh-CN")
+        end
+
+        it "Get a component's translations and locale type is nil" do
+            expect(SgtnClient::Translation.getStrings("about", nil)["messages"]["about.message"]).to eq("fall back about")
+            #expect{SgtnClient::Translation.getStrings("about", 123)}.to raise_error(NoMethodError)
             ##puts SgtnClient::Translation.getStrings("about", "zh-CN")
         end
 

--- a/autotest/client/ruby/spec/Translation_spec.rb
+++ b/autotest/client/ruby/spec/Translation_spec.rb
@@ -21,9 +21,9 @@ describe "Translation test" do
             expect(SgtnClient::Translation.getString("about", "about.message", "en")).to eq("fall back about")
         end
 
-        it "Get a string's translation and locale is fr-FR" do
+        it "Get a string's translation and locale is fr" do
             #SgtnClient::Source.loadBundles("de")
-            expect(SgtnClient::Translation.getString("about", "about.message", "fr-FR")).to eq("test fr key")
+            expect(SgtnClient::Translation.getString("about", "about.message", :fr)).to eq("test fr key")
         end
 
         it "Get a string's translation and locale is zh-Hans" do
@@ -61,7 +61,13 @@ describe "Translation test" do
 
 
         it "Get a string's translation and locale argument type is incorrect" do
-            expect{SgtnClient::Translation.getString("about", "about.message", 123)}.to raise_error(NoMethodError)
+            #expect{SgtnClient::Translation.getString("about", "about.message", 123)}.to raise_error(NoMethodError)
+            expect(SgtnClient::Translation.getString("about", "about.message", 123)).to eq("fall back about")
+        end
+
+        it "Get a string's translation and locale argument type is nil" do
+            #expect{SgtnClient::Translation.getString("about", "about.message", 123)}.to raise_error(NoMethodError)
+            expect(SgtnClient::Translation.getString("about", "about.message", nil)).to eq("fall back about")
         end
 
         # it "Get a string's translation and key type is incorrect" do
@@ -165,7 +171,14 @@ describe "Translation test" do
         end
 
         it "Get a component's translations and locale type is incorrect" do
-            expect{SgtnClient::Translation.getStrings("about", 123)}.to raise_error(NoMethodError)
+            #expect{SgtnClient::Translation.getStrings("about", 123)}.to raise_error(NoMethodError)
+            expect(SgtnClient::Translation.getStrings("about", 123)["messages"]["about.message"]).to eq("fall back about")
+            ##puts SgtnClient::Translation.getStrings("about", "zh-CN")
+        end
+
+        it "Get a component's translations and locale type is nil" do
+            expect(SgtnClient::Translation.getStrings("about", nil)["messages"]["about.message"]).to eq("fall back about")
+            #expect{SgtnClient::Translation.getStrings("about", 123)}.to raise_error(NoMethodError)
             ##puts SgtnClient::Translation.getStrings("about", "zh-CN")
         end
 


### PR DESCRIPTION
1, Change the expect result, when locale is nil, not support language or int number, the get string method return default value rather than throw a error --- PR:https://github.com/vmware/singleton/pull/1495
2, If the locale is of type Symbol, convert it first to String, such as: :fr to "fr" ---PR:https://github.com/vmware/singleton/pull/1496