### PR TITLE
[Ruby Client] Correct caching and usage of source vs. "en" bundles

### DIFF
--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -59,6 +59,8 @@ module SgtnClient
       def self.getStrings(component, locale)
         SgtnClient.logger.debug "[Translation][getStrings]component=#{component}, locale=#{locale}"
         locale = SgtnClient::LocaleUtil.get_best_locale(locale)
+        return getSources(component, locale) if locale == LocaleUtil.get_source_locale
+
         items = get_cs(component, locale)
         default = SgtnClient::Config.configurations.default
         if items.nil? || items["messages"] == nil

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -86,8 +86,7 @@ module SgtnClient
       end
 
       def self.get_cs(component, locale)
-        locale = SgtnClient::LocaleUtil.process_locale(locale)
-        flocale = SgtnClient::LocaleUtil.fallback(locale)
+        flocale = SgtnClient::LocaleUtil.process_locale(locale)
         cache_key = SgtnClient::CacheUtil.get_cachekey(component, flocale)
         SgtnClient.logger.debug "[Translation][get_cs]cache_key=#{cache_key}"
         expired, items = SgtnClient::CacheUtil.get_cache(cache_key)

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -59,7 +59,7 @@ module SgtnClient
       def self.getStrings(component, locale)
         SgtnClient.logger.debug "[Translation][getStrings]component=#{component}, locale=#{locale}"
         locale = SgtnClient::LocaleUtil.get_best_locale(locale)
-        return getSources(component, locale) if locale == LocaleUtil.get_source_locale
+        return Source.getSources(component, locale) if locale == LocaleUtil.get_source_locale
 
         items = get_cs(component, locale)
         default = SgtnClient::Config.configurations.default

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -59,8 +59,6 @@ module SgtnClient
       def self.getStrings(component, locale)
         SgtnClient.logger.debug "[Translation][getStrings]component=#{component}, locale=#{locale}"
         locale = SgtnClient::LocaleUtil.get_best_locale(locale)
-        return Source.getSources(component, locale) if locale == LocaleUtil.get_source_locale
-
         items = get_cs(component, locale)
         default = SgtnClient::Config.configurations.default
         if items.nil? || items["messages"] == nil

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -81,11 +81,7 @@ module SgtnClient
 
       def self.getTranslation(component, key, locale)
         locale = SgtnClient::LocaleUtil.get_best_locale(locale)
-        if locale == LocaleUtil.get_source_locale
-          items = Source.getSources(component, locale)
-        else
-          items = get_cs(component, locale)
-        end
+        items = get_cs(component, locale)
         if items.nil? || items["messages"] == nil
           nil
         else

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -58,6 +58,7 @@ module SgtnClient
 
       def self.getStrings(component, locale)
         SgtnClient.logger.debug "[Translation][getStrings]component=#{component}, locale=#{locale}"
+        locale = SgtnClient::LocaleUtil.process_locale(locale)
         items = get_cs(component, locale)
         default = SgtnClient::Config.configurations.default
         if items.nil? || items["messages"] == nil
@@ -79,6 +80,7 @@ module SgtnClient
       private
 
       def self.getTranslation(component, key, locale)
+        locale = SgtnClient::LocaleUtil.process_locale(locale)
         items = get_cs(component, locale)
         if items.nil? || items["messages"] == nil
           nil
@@ -88,12 +90,11 @@ module SgtnClient
       end
 
       def self.get_cs(component, locale)
-        flocale = SgtnClient::LocaleUtil.process_locale(locale)
-        cache_key = SgtnClient::CacheUtil.get_cachekey(component, flocale)
+        cache_key = SgtnClient::CacheUtil.get_cachekey(component, locale)
         SgtnClient.logger.debug "[Translation][get_cs]cache_key=#{cache_key}"
         expired, items = SgtnClient::CacheUtil.get_cache(cache_key)
         if items.nil? || expired
-          items = load(component, flocale)
+          items = load(component, locale)
           if items.nil?
             items = SgtnClient::Source.getSources(component, SgtnClient::Config.configurations.default)
             SgtnClient::Core::Cache.put(cache_key, items, 60)

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -90,6 +90,13 @@ module SgtnClient
       end
 
       def self.get_cs(component, locale)
+        # source locale always return source bundle
+        if locale == LocaleUtil.get_source_locale
+          sources = SgtnClient::Source.getSources(component, SgtnClient::Config.configurations.default)
+          messages = sources&.first&.last
+          return {'locale' => locale, 'component' => component, 'messages' => messages} if messages
+        end
+
         cache_key = SgtnClient::CacheUtil.get_cachekey(component, locale)
         SgtnClient.logger.debug "[Translation][get_cs]cache_key=#{cache_key}"
         expired, items = SgtnClient::CacheUtil.get_cache(cache_key)

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -83,7 +83,11 @@ module SgtnClient
 
       def self.getTranslation(component, key, locale)
         locale = SgtnClient::LocaleUtil.get_best_locale(locale)
-        items = get_cs(component, locale)
+        if locale == LocaleUtil.get_source_locale
+          items = Source.getSources(component, locale)
+        else
+          items = get_cs(component, locale)
+        end
         if items.nil? || items["messages"] == nil
           nil
         else

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -58,7 +58,7 @@ module SgtnClient
 
       def self.getStrings(component, locale)
         SgtnClient.logger.debug "[Translation][getStrings]component=#{component}, locale=#{locale}"
-        locale = SgtnClient::LocaleUtil.process_locale(locale)
+        locale = SgtnClient::LocaleUtil.get_best_locale(locale)
         items = get_cs(component, locale)
         default = SgtnClient::Config.configurations.default
         if items.nil? || items["messages"] == nil
@@ -80,7 +80,7 @@ module SgtnClient
       private
 
       def self.getTranslation(component, key, locale)
-        locale = SgtnClient::LocaleUtil.process_locale(locale)
+        locale = SgtnClient::LocaleUtil.get_best_locale(locale)
         items = get_cs(component, locale)
         if items.nil? || items["messages"] == nil
           nil

--- a/lib/sgtn-client/api/translation.rb
+++ b/lib/sgtn-client/api/translation.rb
@@ -1,3 +1,5 @@
+#Copyright 2019-2022 VMware, Inc.
+#SPDX-License-Identifier: EPL-2.0
 require 'multi_json'
 
 module SgtnClient

--- a/lib/sgtn-client/util/cache-util.rb
+++ b/lib/sgtn-client/util/cache-util.rb
@@ -38,13 +38,7 @@ module SgtnClient
         env = SgtnClient::Config.default_environment
         product_name = SgtnClient::Config.configurations[env]["product_name"]
         version = SgtnClient::Config.configurations[env]["version"].to_s
-        default_l = SgtnClient::Config.configurations[env]["default_language"]
-        if default_l == nil
-          default_l = 'en'
-        end
-        lc = locale == default_l ? SgtnClient::Config.configurations.default: locale
-        SgtnClient.logger.debug "[CacheUtil]get cache key: #{lc}"
-        return product_name + "_" + version + "_" + component + "_" + lc
+        product_name + "_" + version + "_" + component + "_" + locale
       end
   end
 

--- a/lib/sgtn-client/util/cache-util.rb
+++ b/lib/sgtn-client/util/cache-util.rb
@@ -1,3 +1,5 @@
+#Copyright 2019-2022 VMware, Inc.
+#SPDX-License-Identifier: EPL-2.0
 require 'erb'
 require 'yaml'
 

--- a/lib/sgtn-client/util/locale-util.rb
+++ b/lib/sgtn-client/util/locale-util.rb
@@ -12,12 +12,12 @@ module SgtnClient
                   }
 
     class LocaleUtil
-        def self.process_locale(locale)
-            flocale = fallback(process_input(locale))
+        def self.get_best_locale(locale)
+            flocale = fallback(process_locale(locale))
             flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale()
             return flocale
         end
-        def self.process_input(locale=nil)
+        def self.process_locale(locale=nil)
             locale ||= SgtnClient::Config.configurations.default
             locale.to_s
         end

--- a/lib/sgtn-client/util/locale-util.rb
+++ b/lib/sgtn-client/util/locale-util.rb
@@ -1,3 +1,5 @@
+#Copyright 2019-2022 VMware, Inc.
+#SPDX-License-Identifier: EPL-2.0
 module SgtnClient
 
     DEFAULT_LOCALES = ['en', 'de', 'es', 'fr', 'ko', 'ja', 'zh-Hans', 'zh-Hant']

--- a/lib/sgtn-client/util/locale-util.rb
+++ b/lib/sgtn-client/util/locale-util.rb
@@ -12,9 +12,9 @@ module SgtnClient
                   }
 
     class LocaleUtil
-        def self.process_locale(locale)
+        def self.process_locale(locale, remoteSource=false)
             flocale = fallback(process_input(locale))
-            flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale()
+            flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale() and remoteSource == false
             return flocale
         end
         def self.process_input(locale=nil)

--- a/lib/sgtn-client/util/locale-util.rb
+++ b/lib/sgtn-client/util/locale-util.rb
@@ -13,9 +13,7 @@ module SgtnClient
 
     class LocaleUtil
         def self.get_best_locale(locale)
-            flocale = fallback(process_locale(locale))
-            flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale()
-            return flocale
+            fallback(process_locale(locale))
         end
         def self.process_locale(locale=nil)
             locale ||= SgtnClient::Config.configurations.default

--- a/lib/sgtn-client/util/locale-util.rb
+++ b/lib/sgtn-client/util/locale-util.rb
@@ -12,9 +12,9 @@ module SgtnClient
                   }
 
     class LocaleUtil
-        def self.process_locale(locale, remoteSource=false)
+        def self.process_locale(locale)
             flocale = fallback(process_input(locale))
-            flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale() and remoteSource == false
+            flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale()
             return flocale
         end
         def self.process_input(locale=nil)

--- a/lib/sgtn-client/util/locale-util.rb
+++ b/lib/sgtn-client/util/locale-util.rb
@@ -10,7 +10,12 @@ module SgtnClient
                   }
 
     class LocaleUtil
-        def self.process_locale(locale=nil)
+        def self.process_locale(locale)
+            flocale = fallback(process_input(locale))
+            flocale = SgtnClient::Config.configurations.default if flocale == get_source_locale()
+            return flocale
+        end
+        def self.process_input(locale=nil)
             locale ||= SgtnClient::Config.configurations.default
             locale.to_s
         end
@@ -30,6 +35,11 @@ module SgtnClient
                 end
             end 
             return locale
+        end
+        def self.get_source_locale
+            env = SgtnClient::Config.default_environment
+            source_locale = SgtnClient::Config.configurations[env]["default_language"]
+            source_locale || 'en'
         end
     end
 end

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -20,23 +20,27 @@ describe SgtnClient do
       expect(SgtnClient::Translation.getString("JAVA", "helloworld", "zh-Hans")).to eq '你好世界'
     end
 
-
-    it "default" do
+    it "get_cachekey" do
       env = SgtnClient::Config.default_environment
-      component = "JAVA"
-      default_language = "default"
-      default_cache_key = "test_4.8.1_JAVA_default"
-      SgtnClient::Source.loadBundles(default_language)
-      config_lang = SgtnClient::Config.configurations[env]["default_language"]
-      if config_lang == nil || config_lang == 'en'
-        expect(SgtnClient::CacheUtil.get_cachekey(component, SgtnClient::LocaleUtil.fallback('en-US'))).to eq default_cache_key
-        expect(SgtnClient::CacheUtil.get_cachekey(component, SgtnClient::LocaleUtil.fallback('de-DE'))).to eq 'test_4.8.1_JAVA_de'
-      end
-      # reset the default language to 'zh-Hans'
-      SgtnClient::Config.configurations[env]["default_language"] = 'zh-Hans'
-      expect(SgtnClient::CacheUtil.get_cachekey(component, SgtnClient::LocaleUtil.fallback('zh-Hans'))).to eq default_cache_key
-      expect(SgtnClient::CacheUtil.get_cachekey(component, SgtnClient::LocaleUtil.fallback('zh-CN'))).to eq default_cache_key
-      expect(SgtnClient::CacheUtil.get_cachekey(component, SgtnClient::LocaleUtil.fallback('en-US'))).to eq 'test_4.8.1_JAVA_en'
+      product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
+      version = SgtnClient::Config.configurations[env]["version"].to_s
+      expect(SgtnClient::CacheUtil.get_cachekey("java", "zh-Hans")).to eq "#{product_name}_#{version}_java_zh-Hans"
+    end
+
+    it "get_cachekey" do
+      env = SgtnClient::Config.default_environment
+      product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
+      version = SgtnClient::Config.configurations[env]["version"].to_s
+      locale = "zh-Hans"
+      expect(SgtnClient::CacheUtil.get_cachekey("java", locale)).to eq "#{product_name}_#{version}_java_#{locale}"
+    end
+
+    it "get_cachekey_sourceLocale" do
+      env = SgtnClient::Config.default_environment
+      product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
+      version = SgtnClient::Config.configurations[env]["version"].to_s
+      locale = SgtnClient::Config.configurations.default
+      expect(SgtnClient::CacheUtil.get_cachekey("java", locale)).to eq "#{product_name}_#{version}_java_#{locale}"
     end
 
   end

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -30,11 +30,21 @@ describe SgtnClient do
       expect(SgtnClient::CacheUtil.get_cachekey("java", locale)).to eq "#{product_name}_#{version}_java_#{locale}"
     end
 
-    it "get_cachekey_sourceLocale" do
+    it "get_cachekey_source_bundle" do
       env = SgtnClient::Config.default_environment
       product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
       version = SgtnClient::Config.configurations[env]["version"].to_s
       locale = SgtnClient::Config.configurations.default
+      expect(locale).to eq 'default'
+      expect(SgtnClient::CacheUtil.get_cachekey("java", locale)).to eq "#{product_name}_#{version}_java_#{locale}"
+    end
+
+    it "get_cachekey_en_locale" do
+      env = SgtnClient::Config.default_environment
+      product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
+      version = SgtnClient::Config.configurations[env]["version"].to_s
+      locale = SgtnClient::LocaleUtil.get_source_locale()
+      expect(locale).to eq 'en'
       expect(SgtnClient::CacheUtil.get_cachekey("java", locale)).to eq "#{product_name}_#{version}_java_#{locale}"
     end
 

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -1,3 +1,5 @@
+#Copyright 2019-2022 VMware, Inc.
+#SPDX-License-Identifier: EPL-2.0
 require 'spec_helper'
 
 describe SgtnClient do

--- a/spec/unit/cache_spec.rb
+++ b/spec/unit/cache_spec.rb
@@ -26,13 +26,6 @@ describe SgtnClient do
       env = SgtnClient::Config.default_environment
       product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
       version = SgtnClient::Config.configurations[env]["version"].to_s
-      expect(SgtnClient::CacheUtil.get_cachekey("java", "zh-Hans")).to eq "#{product_name}_#{version}_java_zh-Hans"
-    end
-
-    it "get_cachekey" do
-      env = SgtnClient::Config.default_environment
-      product_name = SgtnClient::Config.configurations[env]["product_name"].to_s
-      version = SgtnClient::Config.configurations[env]["version"].to_s
       locale = "zh-Hans"
       expect(SgtnClient::CacheUtil.get_cachekey("java", locale)).to eq "#{product_name}_#{version}_java_#{locale}"
     end

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -10,14 +10,14 @@ describe SgtnClient do
       SgtnClient::Source.loadBundles("default")
     end
 
-    it "process_locale" do
-      expect(SgtnClient::LocaleUtil.process_locale('ja')).to eq 'ja'
+    it "get_best_locale" do
+      expect(SgtnClient::LocaleUtil.get_best_locale('ja')).to eq 'ja'
     end
-    it "process_locale_sameSourceAndTarget" do
-      expect(SgtnClient::LocaleUtil.process_locale('en')).to eq SgtnClient::Config.configurations.default
+    it "get_best_locale_sameSourceAndTarget" do
+      expect(SgtnClient::LocaleUtil.get_best_locale('en')).to eq SgtnClient::Config.configurations.default
     end
-    it "process_locale_targetLocaleIsNil" do
-      expect(SgtnClient::LocaleUtil.process_locale(nil)).to eq SgtnClient::Config.configurations.default
+    it "get_best_locale_targetLocaleIsNil" do
+      expect(SgtnClient::LocaleUtil.get_best_locale(nil)).to eq SgtnClient::Config.configurations.default
     end
     
     it "fallback_targetLocaleIsSource" do
@@ -36,16 +36,16 @@ describe SgtnClient do
       expect(SgtnClient::LocaleUtil.fallback('kong-kong')).to eq 'kong-kong'
     end
 
-    it "process_input" do
-      expect(SgtnClient::LocaleUtil.process_input('en')).to eq 'en'
-      expect(SgtnClient::LocaleUtil.process_input('de-DE')).to eq 'de-DE'
-      expect(SgtnClient::LocaleUtil.process_input(:'de-DE')).to eq 'de-DE'
-      expect(SgtnClient::LocaleUtil.process_input(:ja)).to eq 'ja'
-      expect(SgtnClient::LocaleUtil.process_input(:'ja')).to eq 'ja'
+    it "process_locale" do
+      expect(SgtnClient::LocaleUtil.process_locale('en')).to eq 'en'
+      expect(SgtnClient::LocaleUtil.process_locale('de-DE')).to eq 'de-DE'
+      expect(SgtnClient::LocaleUtil.process_locale(:'de-DE')).to eq 'de-DE'
+      expect(SgtnClient::LocaleUtil.process_locale(:ja)).to eq 'ja'
+      expect(SgtnClient::LocaleUtil.process_locale(:'ja')).to eq 'ja'
     end
 
-    it "process_input_nil" do
-      expect(SgtnClient::LocaleUtil.process_input(nil)).to eq SgtnClient::Config.configurations.default
+    it "process_locale_nil" do
+      expect(SgtnClient::LocaleUtil.process_locale(nil)).to eq SgtnClient::Config.configurations.default
     end
 
     it "get_source_locale" do

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -18,6 +18,10 @@ describe SgtnClient do
       allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(1).times.and_return('en')
       expect(SgtnClient::LocaleUtil.process_locale('en')).to eq SgtnClient::Config.configurations.default
     end
+    it "process_locale_remoteSource" do
+      allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(1).times.and_return('en')
+      expect(SgtnClient::LocaleUtil.process_locale('en', true)).to eq 'en'
+    end
     it "process_locale_differentSourceAndTarget" do
       allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(2).times.and_return('en')
       expect(SgtnClient::LocaleUtil.process_locale('ja')).to eq 'ja'

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -11,19 +11,18 @@ describe SgtnClient do
     end
 
     it "process_locale" do
-      allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(1).times.and_return('en')
       expect(SgtnClient::LocaleUtil.process_locale('ja')).to eq 'ja'
     end
     it "process_locale_sameSourceAndTarget" do
-      allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(1).times.and_return('en')
       expect(SgtnClient::LocaleUtil.process_locale('en')).to eq SgtnClient::Config.configurations.default
     end
-    it "process_locale_differentSourceAndTarget" do
-      allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(2).times.and_return('en')
-      expect(SgtnClient::LocaleUtil.process_locale('ja')).to eq 'ja'
-      expect(SgtnClient::LocaleUtil.process_locale('zh-Hans')).to eq 'zh-Hans'
+    it "process_locale_targetLocaleIsNil" do
+      expect(SgtnClient::LocaleUtil.process_locale(nil)).to eq SgtnClient::Config.configurations.default
     end
-
+    
+    it "fallback_targetLocaleIsSource" do
+      expect(SgtnClient::LocaleUtil.fallback(SgtnClient::Config.configurations.default)).to eq SgtnClient::Config.configurations.default
+    end 
     it "fallback" do
       expect(SgtnClient::LocaleUtil.fallback('ja-JP')).to eq 'ja'
       expect(SgtnClient::LocaleUtil.fallback('de-DE')).to eq 'de'

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -13,14 +13,14 @@ describe SgtnClient do
     it "get_best_locale" do
       expect(SgtnClient::LocaleUtil.get_best_locale('ja')).to eq 'ja'
     end
-    it "get_best_locale_sameSourceAndTarget" do
+    it "get_best_locale_same_source_and_target" do
       expect(SgtnClient::LocaleUtil.get_best_locale('en')).to eq SgtnClient::Config.configurations.default
     end
-    it "get_best_locale_targetLocaleIsNil" do
+    it "get_best_locale_target_locale_is_nil" do
       expect(SgtnClient::LocaleUtil.get_best_locale(nil)).to eq SgtnClient::Config.configurations.default
     end
     
-    it "fallback_targetLocaleIsSource" do
+    it "fallback_target_locale_is_source" do
       expect(SgtnClient::LocaleUtil.fallback(SgtnClient::Config.configurations.default)).to eq SgtnClient::Config.configurations.default
     end 
     it "fallback" do
@@ -54,7 +54,7 @@ describe SgtnClient do
       expect(SgtnClient::LocaleUtil.get_source_locale()).to eq 'ja'
     end
     
-    it "get_source_locale_sourceIsNil" do
+    it "get_source_locale_source_is_nil" do
       env = SgtnClient::Config.default_environment
       SgtnClient::Config.configurations[env]["default_language"] = nil
       expect(SgtnClient::LocaleUtil.get_source_locale()).to eq 'en'

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -13,9 +13,7 @@ describe SgtnClient do
     it "get_best_locale" do
       expect(SgtnClient::LocaleUtil.get_best_locale('ja')).to eq 'ja'
     end
-    it "get_best_locale_same_source_and_target" do
-      expect(SgtnClient::LocaleUtil.get_best_locale('en')).to eq SgtnClient::Config.configurations.default
-    end
+    
     it "get_best_locale_target_locale_is_nil" do
       expect(SgtnClient::LocaleUtil.get_best_locale(nil)).to eq SgtnClient::Config.configurations.default
     end

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -18,10 +18,6 @@ describe SgtnClient do
       allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(1).times.and_return('en')
       expect(SgtnClient::LocaleUtil.process_locale('en')).to eq SgtnClient::Config.configurations.default
     end
-    it "process_locale_remoteSource" do
-      allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(1).times.and_return('en')
-      expect(SgtnClient::LocaleUtil.process_locale('en', true)).to eq 'en'
-    end
     it "process_locale_differentSourceAndTarget" do
       allow(SgtnClient::LocaleUtil).to receive(:get_source_locale).exactly(2).times.and_return('en')
       expect(SgtnClient::LocaleUtil.process_locale('ja')).to eq 'ja'

--- a/spec/unit/locale_spec.rb
+++ b/spec/unit/locale_spec.rb
@@ -1,3 +1,5 @@
+#Copyright 2019-2022 VMware, Inc.
+#SPDX-License-Identifier: EPL-2.0
 require 'spec_helper'
 
 describe SgtnClient do

--- a/spec/unit/onclient_spec.rb
+++ b/spec/unit/onclient_spec.rb
@@ -11,7 +11,7 @@ describe SgtnClient do
     end
 
     it "GET_EN" do
-      allow(SgtnClient::LocaleUtil).to receive(:process_locale).exactly(3).times.and_return('en')
+      allow(SgtnClient::LocaleUtil).to receive(:get_best_locale).exactly(3).times.and_return('en')
       expect(SgtnClient::Translation.getString("JAVA", "helloworld", "en")).to eq 'Hello world'
       # get from cache in 2nd time
       expect(SgtnClient::Translation.getString("JAVA", "helloworld", "en")).to eq 'Hello world'
@@ -19,12 +19,12 @@ describe SgtnClient do
     end
 
     it "GET_NIL_LOCALE" do
-      allow(SgtnClient::LocaleUtil).to receive(:process_locale).and_return(SgtnClient::Config.configurations.default)
+      allow(SgtnClient::LocaleUtil).to receive(:get_best_locale).and_return(SgtnClient::Config.configurations.default)
       expect(SgtnClient::Translation.getString("JAVA", "helloworld", nil)).to eq 'Hello world'
     end 
 
     it "GET" do
-      allow(SgtnClient::LocaleUtil).to receive(:process_locale).exactly(3).times.and_return('zh-Hans')
+      allow(SgtnClient::LocaleUtil).to receive(:get_best_locale).exactly(3).times.and_return('zh-Hans')
       expect(SgtnClient::Translation.getString("JAVA", "helloworld", "zh-Hans")).to eq '你好世界'
       # get from cache in 2nd time
       expect(SgtnClient::Translation.getString("JAVA", "helloworld", "zh-Hans")).to eq '你好世界'

--- a/spec/unit/onclient_spec.rb
+++ b/spec/unit/onclient_spec.rb
@@ -1,3 +1,5 @@
+#Copyright 2019-2022 VMware, Inc.
+#SPDX-License-Identifier: EPL-2.0
 require 'spec_helper'
 
 describe SgtnClient do


### PR DESCRIPTION
Part 1 of "splitting [pull 1550](https://github.com/vmware/singleton/pull/1550) into 3 parts":

1.  Loading source bundle in cache and using them directly when target locale is same as source locale
2. Source comparison
3. Moving some methods from translation.rb into a new base.rb file.