### PR TITLE
fix issue: throw expt when locale is nil

### DIFF
--- a/lib/sgtn-client/api/source.rb
+++ b/lib/sgtn-client/api/source.rb
@@ -15,7 +15,7 @@ module SgtnClient
         else
           SgtnClient.logger.debug "[Source][getSource]getting sources from cache with key: " + cache_key
         end
-        s = items.nil?? nil : items[locale][key]
+        s = (items.nil? || items[locale].nil?)? nil : items[locale][key]  
         if items.nil? || s.nil?
           SgtnClient.logger.debug "[Source][getSource]source not found, return key: " + key
           #return key

--- a/lib/sgtn-client/api/source.rb
+++ b/lib/sgtn-client/api/source.rb
@@ -1,3 +1,7 @@
+# 
+#  Copyright 2019-2022 VMware, Inc.
+#  SPDX-License-Identifier: EPL-2.0
+#
 
 module SgtnClient
   

--- a/spec/unit/source_spec.rb
+++ b/spec/unit/source_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe SgtnClient do
+  describe "SourceAPI" do
+
+    before :each do
+      env = SgtnClient::Config.default_environment
+      SgtnClient::Config.configurations[env]["bundle_mode"] = 'offline'
+      @locale="default"
+      @component="NEW"
+      SgtnClient::Source.loadBundles(@locale)
+    end
+
+    it "getSource" do
+      key="new_welcome"
+      str = SgtnClient::Source.getSource(@component, key, SgtnClient::Config.configurations.default)
+      expect(str).to eq 'New %2$s, welcome login %1$s!'
+    end
+
+    it "getSources" do
+      str = SgtnClient::Source.getSources(@component, SgtnClient::Config.configurations.default)
+      expect(str).not_to eq be_nil
+    end
+
+    it "loadBundles" do
+      cache_key = SgtnClient::CacheUtil.get_cachekey(@component, @locale)
+      expect(SgtnClient::CacheUtil.get_cache(cache_key)).not_to eq be_nil
+    end
+
+  end
+
+end

--- a/spec/unit/source_spec.rb
+++ b/spec/unit/source_spec.rb
@@ -1,3 +1,8 @@
+# 
+#  Copyright 2019-2022 VMware, Inc.
+#  SPDX-License-Identifier: EPL-2.0
+#
+
 require 'spec_helper'
 
 describe SgtnClient do

--- a/spec/unit/source_spec.rb
+++ b/spec/unit/source_spec.rb
@@ -11,19 +11,20 @@ describe SgtnClient do
     before :each do
       env = SgtnClient::Config.default_environment
       SgtnClient::Config.configurations[env]["bundle_mode"] = 'offline'
-      @locale="default"
+      @locale=SgtnClient::Config.configurations.default
       @component="NEW"
       SgtnClient::Source.loadBundles(@locale)
     end
 
     it "getSource" do
       key="new_welcome"
-      str = SgtnClient::Source.getSource(@component, key, SgtnClient::Config.configurations.default)
+      str = SgtnClient::Source.getSource(@component, key, @locale)
       expect(str).to eq 'New %2$s, welcome login %1$s!'
     end
 
     it "getSources" do
-      str = SgtnClient::Source.getSources(@component, SgtnClient::Config.configurations.default)
+      str = SgtnClient::Source.getSources(@component, @locale)
+      puts str[@locale]
       expect(str).not_to eq be_nil
     end
 


### PR DESCRIPTION
fix issue: throw expt when locale is nil