### PR TITLE
Revert "speed up loading source (#1712)" to use YAML instead of psych_simple

### DIFF
--- a/lib/sgtn-client/loader/source.rb
+++ b/lib/sgtn-client/loader/source.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: EPL-2.0
 
 require 'pathname'
-require 'psych/simple'
+require 'yaml'
 
 module SgtnClient
   module Common
@@ -25,7 +25,7 @@ module SgtnClient
         total_messages = {}
 
         (@source_bundle_path + component).glob('**/*.{yml, yaml}') do |f|
-          bundle = Psych.simple_load(File.read(f))
+          bundle = YAML.safe_load(File.read(f))
           messages = bundle&.first&.last # TODO: Warn about inconsistent source locale
           if messages.is_a?(Hash)
             total_messages.merge!(messages)

--- a/lib/sgtn-client/loader/source.rb
+++ b/lib/sgtn-client/loader/source.rb
@@ -25,7 +25,7 @@ module SgtnClient
         total_messages = {}
 
         (@source_bundle_path + component).glob('**/*.{yml, yaml}') do |f|
-          bundle = YAML.safe_load(File.read(f))
+          bundle = YAML.load(File.read(f))
           messages = bundle&.first&.last # TODO: Warn about inconsistent source locale
           if messages.is_a?(Hash)
             total_messages.merge!(messages)

--- a/singleton-ruby.gemspec
+++ b/singleton-ruby.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency('multi_json', '~> 1.0')
   s.add_dependency('request_store')
   s.add_dependency('twitter_cldr', '~> 6.6')
-  s.add_dependency('psych-simple', '~> 2.0')
 
   s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
The version of `psych` that `psych-simple` uses is 2 and it's out of date. There isn't a new version of `psych-simple`, so need to change `psych-simple` back to `YAML`.

bundler-1.17.3/lib/bundler/runtime.rb:319:in `check_for_activated_spec!': You have already activated psych 3.0.2, but your Gemfile requires psych 2.2.4. Since psych is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports psych as a default gem. (Gem::LoadError)