### PR TITLE
[Devops][Ruby client]update smoke test code with the Sgtn.get_translations() change

### DIFF
--- a/autotest/client/ruby/spec/mixd/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/mixd/Translation_get_translations_spec.rb
@@ -20,7 +20,7 @@ describe "get_translations online test" do
         it "get component by get_translations and arguments is less than 2" do
             #expect{Sgtn.get_translations("about")}.to raise_error(ArgumentError)
             Sgtn.locale = "de"
-            expect(Sgtn.get_translations("allin")).to eq({"component"=>"allin", "locale"=>"de", "messages"=>{"about.addkey"=>"test value %{name}", "about.change"=>"%{name}, welcome chanege de %{place}!", "about.description"=>"Use this area to provide additional information source", "about.insource"=>"%{name}, only in source %{place}!", "about.key1"=>"fall back key1", "about.key3"=>"fall back key31", "about.message"=>"test de key offline", "about.notequal"=>"{name}, welcome login not equal {place}!", "about.notequal2"=>"%{name}, welcome login not equal source %{place}!", "about.onlyonline"=>"online de 1", "about.sourceandoffline2"=>"test add offline 2", "about.test"=>"test de the %1$s to %2$s", "about.test1"=>"test source the {1} to {2}", "about.testw"=>"%{name}, welcome de %{place}!", "about.title"=>"About de", "about.welcome"=>"{name}, welcome login {place} latest!", "com.vmware.loginsight.web.settings.stats.StatsTable.host"=>"123"}})
+            expect(Sgtn.get_translations("allin")).to eq({"about.addkey"=>"test value %{name}", "about.change"=>"%{name}, welcome chanege de %{place}!", "about.description"=>"Use this area to provide additional information source", "about.insource"=>"%{name}, only in source %{place}!", "about.key1"=>"fall back key1", "about.key3"=>"fall back key31", "about.message"=>"test de key offline", "about.notequal"=>"{name}, welcome login not equal {place}!", "about.notequal2"=>"%{name}, welcome login not equal source %{place}!", "about.onlyonline"=>"online de 1", "about.sourceandoffline2"=>"test add offline 2", "about.test"=>"test de the %1$s to %2$s", "about.test1"=>"test source the {1} to {2}", "about.testw"=>"%{name}, welcome de %{place}!", "about.title"=>"About de", "about.welcome"=>"{name}, welcome login {place} latest!", "com.vmware.loginsight.web.settings.stats.StatsTable.host"=>"123"})
 
         end
 
@@ -31,7 +31,7 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("allin", 'en')).to eq({"component"=>"allin", "locale"=>"en", "messages"=>{"about.addkey"=>"test value %{name}", "about.description"=>"Use this area to provide additional information source", "about.insource"=>"%{name}, only in source %{place}!", "about.key1"=>"fall back key1", "about.key3"=>"fall back key31", "about.message"=>"Your application description page. offline", "about.notequal"=>"{name}, welcome login not equal {place}!", "about.notequal2"=>"%{name}, welcome login not equal source %{place}!", "about.onlyonline"=>"online 1", "about.sourceandoffline2"=>"test add offline 2", "about.test1"=>"test source the {1} to {2}", "about.testw"=>"%{name}, welcome %{place}!", "about.title"=>"About", "about.welcome"=>"{name}, welcome login {place} latest!", "com.vmware.loginsight.web.settings.stats.StatsTable.host"=>"123"}})
+            expect(Sgtn.get_translations("allin", 'en')).to eq({"about.addkey"=>"test value %{name}", "about.description"=>"Use this area to provide additional information source", "about.insource"=>"%{name}, only in source %{place}!", "about.key1"=>"fall back key1", "about.key3"=>"fall back key31", "about.message"=>"Your application description page. offline", "about.notequal"=>"{name}, welcome login not equal {place}!", "about.notequal2"=>"%{name}, welcome login not equal source %{place}!", "about.onlyonline"=>"online 1", "about.sourceandoffline2"=>"test add offline 2", "about.test1"=>"test source the {1} to {2}", "about.testw"=>"%{name}, welcome %{place}!", "about.title"=>"About", "about.welcome"=>"{name}, welcome login {place} latest!", "com.vmware.loginsight.web.settings.stats.StatsTable.host"=>"123"})
         end
 
         it "get component by get_translations and component is int" do
@@ -48,15 +48,15 @@ describe "get_translations online test" do
         end
         
         it "get component by get_translations and component not in source" do
-            expect(Sgtn.get_translations("onlyonline", 'en')).to eq({"component"=>"onlyonline", "locale"=>"en", "messages"=>{"contact.applicationname"=>"Singleton Sample Web Application", "contact.message"=>"Your contact page.", "contact.title"=>"Contact"}})
+            expect(Sgtn.get_translations("onlyonline", 'en')).to eq({"contact.applicationname"=>"Singleton Sample Web Application", "contact.message"=>"Your contact page.", "contact.title"=>"Contact"})
         end
 
         it "get component by get_translations and component not in source and locale is de___new dleng bug" do
-            expect(Sgtn.get_translations("onlyonline", 'de')).to eq({"component"=>"onlyonline", "locale"=>"de", "messages"=>{"contact.applicationname"=>"Singleton Sample Web Application", "contact.message"=>"Your contact de page.", "contact.title"=>"Contact"}})
+            expect(Sgtn.get_translations("onlyonline", 'de')).to eq({"contact.applicationname"=>"Singleton Sample Web Application", "contact.message"=>"Your contact de page.", "contact.title"=>"Contact"})
         end
 
         it "get component by get_translations and component not in source and locale is de" do
-            expect(Sgtn.get_translations("onlyoffline", 'de')).to eq({"component"=>"onlyoffline", "locale"=>"de", "messages"=>{"onlyoffline.key1"=>"test value de1", "onlyoffline.key2"=>"test value 2 source", "onlyoffline.key3"=>"test value  de 3"}})
+            expect(Sgtn.get_translations("onlyoffline", 'de')).to eq({"onlyoffline.key1"=>"test value de1", "onlyoffline.key2"=>"test value 2 source", "onlyoffline.key3"=>"test value  de 3"})
         end
 
         

--- a/autotest/client/ruby/spec/offline/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/offline/Translation_get_translations_spec.rb
@@ -20,7 +20,7 @@ describe "get_translations offline test" do
         it "get component by get_translations and arguments is less than 2" do
             #expect{Sgtn.get_translations("about")}.to raise_error(ArgumentError)
             Sgtn.locale = "de"
-            expect(Sgtn.get_translations("about")).to eq({"component"=>"about", "locale"=>"de", "messages"=>{"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"}})
+            expect(Sgtn.get_translations("about")).to eq({"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"})
 
         end
 
@@ -31,7 +31,7 @@ describe "get_translations offline test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about", 'en')).to eq({"component"=>"about", "locale"=>"en", "messages"=>{"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"}})
+            expect(Sgtn.get_translations("about", 'en')).to eq({"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"})
         end
 
         it "get component by get_translations and component is int" do
@@ -48,61 +48,61 @@ describe "get_translations offline test" do
         end
         
         it "get component by get_translations and component not in source" do
-            expect(Sgtn.get_translations("contact", 'en')).to eq({"component"=>"contact", "locale"=>"en", "messages"=>{"contact.key1"=>"test key 1", "contact.key2"=>"test key 2"}})
+            expect(Sgtn.get_translations("contact", 'en')).to eq({"contact.key1"=>"test key 1", "contact.key2"=>"test key 2"})
         end
 
         it "get component by get_translations and component not in source and locale is de___new dleng bug" do
-            expect(Sgtn.get_translations("contact", 'de')).to eq({"component"=>"contact", "locale"=>"de", "messages"=>{"contact.key1"=>"test key de 1", "contact.key2"=>"test key de 2"}})
+            expect(Sgtn.get_translations("contact", 'de')).to eq({"contact.key1"=>"test key de 1", "contact.key2"=>"test key de 2"})
         end
 
         it "get component by get_translations and component in source and locale is de" do
-            expect(Sgtn.get_translations("about2", 'de')).to eq({"component"=>"about2", "locale"=>"en", "messages"=>{"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"}})
+            expect(Sgtn.get_translations("about2", 'de')).to eq({"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'en')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'en')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'de')).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'de')).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'da')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'da')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
             Sgtn.locale = nil
-            expect(Sgtn.get_translations("intest", nil)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", nil)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 123)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 123)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"component"=>"intest", "locale"=>"zh-Hans", "messages"=>{"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal___new bug 1691" do
-            expect(Sgtn.get_translations("intest", "DE")).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "DE")).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end 
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"component"=>"intest", "locale"=>"fr-CA", "messages"=>{"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
     end

--- a/autotest/client/ruby/spec/online/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/online/Translation_get_translations_spec.rb
@@ -20,7 +20,7 @@ describe "get_translations online test" do
         it "get component by get_translations and arguments is less than 2" do
             #expect{Sgtn.get_translations("about")}.to raise_error(ArgumentError)
             Sgtn.locale = "de"
-            expect(Sgtn.get_translations("about")).to eq({"component"=>"about", "locale"=>"de", "messages"=>{"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"}})
+            expect(Sgtn.get_translations("about")).to eq({"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"})
 
         end
 
@@ -31,7 +31,7 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about", 'en')).to eq({"component"=>"about", "locale"=>"en", "messages"=>{"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"}})
+            expect(Sgtn.get_translations("about", 'en')).to eq({"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"})
         end
 
         it "get component by get_translations and component is int" do
@@ -48,61 +48,61 @@ describe "get_translations online test" do
         end
         
         it "get component by get_translations and component not in source" do
-            expect(Sgtn.get_translations("contact", 'en')).to eq({"component"=>"contact", "locale"=>"en", "messages"=>{"contact.key1"=>"test key 1", "contact.key2"=>"test key 2"}})
+            expect(Sgtn.get_translations("contact", 'en')).to eq({"contact.key1"=>"test key 1", "contact.key2"=>"test key 2"})
         end
 
         it "get component by get_translations and component not in source and locale is de___new dleng bug" do
-            expect(Sgtn.get_translations("contact", 'de')).to eq({"component"=>"contact", "locale"=>"de", "messages"=>{"contact.key1"=>"test key de 1", "contact.key2"=>"test key de 2"}})
+            expect(Sgtn.get_translations("contact", 'de')).to eq({"contact.key1"=>"test key de 1", "contact.key2"=>"test key de 2"})
         end
 
         it "get component by get_translations and component not in source and locale is de" do
-            expect(Sgtn.get_translations("about2", 'de')).to eq({"component"=>"about2", "locale"=>"en", "messages"=>{"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"}})
+            expect(Sgtn.get_translations("about2", 'de')).to eq({"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'en')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'en')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'de')).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'de')).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'da')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'da')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
             Sgtn.locale = nil
-            expect(Sgtn.get_translations("intest", nil)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", nil)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 123)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 123)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"component"=>"intest", "locale"=>"zh-Hans", "messages"=>{"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "DE")).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "DE")).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end 
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"component"=>"intest", "locale"=>"fr-CA", "messages"=>{"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
     end

--- a/autotest/client/ruby/spec/online/Translation_translate_spec.rb
+++ b/autotest/client/ruby/spec/online/Translation_translate_spec.rb
@@ -168,24 +168,6 @@ describe "tmplete 1 test" do
             #expect(SgtnClient::Translation.getString("about", "about.message", "en-US")).to eq("Your application description page. offline")
         end
 
-        it "Get a string's translation and locale is singleton locale" do
-            Sgtn.locale = "de"
-            expect(Sgtn.translate('about.testw', 'about',name:"hhh" , place:"test")).to eq("hhh, welcome de test!")
-            expect(Sgtn.translate('about.message', 'about')).to eq("test de key")
-            #expect(SgtnClient::Translation.getString("about", "about.message", "en-US")).to eq("Your application description page. offline")
-        end
-
-        it "Get a string's translation and locale is singleton locale and default value" do
-            Sgtn.locale = "de"
-            expect(Sgtn.translate('about.addkey', 'about',name:"hhh") {"default value"}) .to eq("test value hhh")
-            expect(Sgtn.translate('about.notexist', 'about',name:"hhhh") {"default value %{name}"}).to eq("default value hhhh")
-            expect(Sgtn.translate('about.notequal2', 'about',name:"hhhh" , place: "change") {"default value %{name} %{place}"}).to eq("hhhh, welcome login not equal source change!")
-            #expect(SgtnClient::Translation.getString("about", "about.message", "en-US")).to eq("Your application description page. offline")
-        end
-
-
-
-
 
 
     end

--- a/autotest/client/ruby/spec/onlineandoffline/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/onlineandoffline/Translation_get_translations_spec.rb
@@ -20,7 +20,7 @@ describe "get_translations online test" do
         it "get component by get_translations and arguments is less than 2" do
             #expect{Sgtn.get_translations("about")}.to raise_error(ArgumentError)
             Sgtn.locale = "de"
-            expect(Sgtn.get_translations("about")).to eq({"component"=>"about", "locale"=>"de", "messages"=>{"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"}})
+            expect(Sgtn.get_translations("about")).to eq({"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"})
 
         end
 
@@ -31,7 +31,7 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about", 'en')).to eq({"component"=>"about", "locale"=>"en", "messages"=>{"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"}})
+            expect(Sgtn.get_translations("about", 'en')).to eq({"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"})
         end
 
         it "get component by get_translations and component is int" do
@@ -48,57 +48,57 @@ describe "get_translations online test" do
         end
         
         it "get component by get_translations and component only in online" do
-            expect(Sgtn.get_translations("onlyonline", 'en')).to eq({"component"=>"onlyonline", "locale"=>"en", "messages"=>{"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"}})
+            expect(Sgtn.get_translations("onlyonline", 'en')).to eq({"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"})
         end
 
         it "get component by get_translations and component only in offline" do
-            expect(Sgtn.get_translations("onlyoffline", 'de')).to eq({"component"=>"onlyoffline", "locale"=>"de", "messages"=>{"onlyoffline.key1"=>"add value de 1", "onlyoffline.key2"=>"add value de 2", "onlyoffline.key3"=>"add value de 3", "onlyoffline.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("onlyoffline", 'de')).to eq({"onlyoffline.key1"=>"add value de 1", "onlyoffline.key2"=>"add value de 2", "onlyoffline.key3"=>"add value de 3", "onlyoffline.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'en')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'en')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'de')).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'de')).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'da')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'da')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
             Sgtn.locale = nil
-            expect(Sgtn.get_translations("intest", nil)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", nil)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 123)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 123)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"component"=>"intest", "locale"=>"zh-Hans", "messages"=>{"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal___new bug 1691" do
-            expect(Sgtn.get_translations("intest", "DE")).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "DE")).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end 
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"component"=>"intest", "locale"=>"fr-CA", "messages"=>{"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
     end

--- a/autotest/client/ruby/spec/onlyoffline/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/onlyoffline/Translation_get_translations_spec.rb
@@ -20,7 +20,7 @@ describe "get_translations online test" do
         it "get component by get_translations and arguments is less than 2" do
             #expect{Sgtn.get_translations("about")}.to raise_error(ArgumentError)
             Sgtn.locale = "de"
-            expect(Sgtn.get_translations("about")).to eq({"component"=>"about", "locale"=>"de", "messages"=>{"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"}})
+            expect(Sgtn.get_translations("about")).to eq({"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"})
 
         end
 
@@ -31,7 +31,7 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about", 'en')).to eq({"component"=>"about", "locale"=>"en", "messages"=>{"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"}})
+            expect(Sgtn.get_translations("about", 'en')).to eq({"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"})
         end
 
         it "get component by get_translations and component is int" do
@@ -56,41 +56,41 @@ describe "get_translations online test" do
         # end
 
         it "get component by get_translations and component not in source and locale is de" do
-            expect(Sgtn.get_translations("common", 'de')).to eq({"component"=>"common", "locale"=>"en", "messages"=>{"common.about"=>"About", "common.applicationname"=>"Sample Application", "common.contact"=>"Contact", "common.home"=>"Home"}})
+            expect(Sgtn.get_translations("common", 'de')).to eq({"common.about"=>"About", "common.applicationname"=>"Sample Application", "common.contact"=>"Contact", "common.home"=>"Home"})
         end
 
         it "get component by get_translations and source not equal debug" do
-            expect(Sgtn.get_translations("intest", 'en')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'en')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'de')).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value de 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'de')).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value de 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'da')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'da')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
             Sgtn.locale = nil
-            expect(Sgtn.get_translations("intest", nil)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", nil)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 123)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 123)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
         
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"component"=>"intest", "locale"=>"zh-Hans", "messages"=>{"intest.key1"=>"add value zh 1", "intest.key2"=>"add value zh 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"intest.key1"=>"add value zh 1", "intest.key2"=>"add value zh 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"})
         end
 
         # it "get component by get_translations and source not equal___new bug 1691" do
@@ -98,11 +98,11 @@ describe "get_translations online test" do
         # end 
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"component"=>"intest", "locale"=>"fr-CA", "messages"=>{"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value fr-CA 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value fr-CA 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value 2", "intest.key4"=>"add value 4"})
         end
 
     end

--- a/autotest/client/ruby/spec/onlyoffline/Translation_translate_spec.rb
+++ b/autotest/client/ruby/spec/onlyoffline/Translation_translate_spec.rb
@@ -161,7 +161,6 @@ describe "tmplete 1 test" do
             Sgtn.locale = "de"
             expect(Sgtn.translate('about.testw', 'about',name:"hhh" , place:"test")).to eq("hhh, welcome de test!")
             expect(Sgtn.translate('about.message', 'about')).to eq("test de key offline")
-            #expect(SgtnClient::Translation.getString("about", "about.message", "en-US")).to eq("Your application description page. offline")
         end
 
         it "Get a string's translation and locale is singleton locale and default value" do
@@ -169,10 +168,7 @@ describe "tmplete 1 test" do
             expect(Sgtn.translate('about.addkey', 'about',name:"hhh") {"default value"}) .to eq("test value hhh")
             expect(Sgtn.translate('about.notexist', 'about',name:"hhhh") {"default value %{name}"}).to eq("default value hhhh")
             expect(Sgtn.translate('about.notequal2', 'about',name:"hhhh" , place: "change") {"default value %{name} %{place}"}).to eq("hhhh, welcome login not equal source change!")
-            #expect(SgtnClient::Translation.getString("about", "about.message", "en-US")).to eq("Your application description page. offline")
         end
-
-
 
 
 

--- a/autotest/client/ruby/spec/onlyserver/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/onlyserver/Translation_get_translations_spec.rb
@@ -20,7 +20,7 @@ describe "get_translations online test" do
         it "get component by get_translations and arguments is less than 2" do
             #expect{Sgtn.get_translations("about")}.to raise_error(ArgumentError)
             Sgtn.locale = "de"
-            expect(Sgtn.get_translations("about")).to eq({"component"=>"about", "locale"=>"de", "messages"=>{"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"}})
+            expect(Sgtn.get_translations("about")).to eq({"about.key1"=>"test value de 1", "about.key2"=>"test value de 2", "about.key3"=>"test value de 3", "about.key4"=>"test value de 4"})
 
         end
 
@@ -31,7 +31,7 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about", 'en')).to eq({"component"=>"about", "locale"=>"en", "messages"=>{"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"}})
+            expect(Sgtn.get_translations("about", 'en')).to eq({"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"})
         end
 
         it "get component by get_translations and component is int" do
@@ -48,7 +48,7 @@ describe "get_translations online test" do
         end
         
         it "get component by get_translations and component not in source" do
-            expect(Sgtn.get_translations("contact", 'en')).to eq({"component"=>"contact", "locale"=>"en", "messages"=>{"contact.key1"=>"test key 1", "contact.key2"=>"test key 2"}})
+            expect(Sgtn.get_translations("contact", 'en')).to eq({"contact.key1"=>"test key 1", "contact.key2"=>"test key 2"})
         end
 
         # it "get component by get_translations and component not in source and locale is de___new dleng bug" do
@@ -57,37 +57,37 @@ describe "get_translations online test" do
 
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'en')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'en')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'de')).to eq({"component"=>"intest", "locale"=>"de", "messages"=>{"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'de')).to eq({"intest.key1"=>"add value de 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value de 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'da')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'da')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'xxxx')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
             Sgtn.locale = nil
-            expect(Sgtn.get_translations("intest", nil)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", nil)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", 123)).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 123)).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal" do
-            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"component"=>"intest", "locale"=>"zh-Hans", "messages"=>{"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "zh-Hans-CN")).to eq({"intest.key1"=>"add value zh 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value zh 3", "intest.key4"=>"add value 4"})
         end
 
         # it "get component by get_translations and source not equal___new bug 1691" do
@@ -95,11 +95,11 @@ describe "get_translations online test" do
         # end 
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"component"=>"intest", "locale"=>"fr-CA", "messages"=>{"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr-CA')).to eq({"intest.key1"=>"add value fr-CA 1", "intest.key2"=>"add value source 2", "intest.key3"=>"add value fr-CA 3", "intest.key4"=>"add value 4"})
         end
 
         it "get component by get_translations and source not equal and locale is de" do
-            expect(Sgtn.get_translations("intest", 'fr')).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", 'fr')).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
     end

--- a/autotest/client/ruby/spec/onlysource/Translation_get_translations_spec.rb
+++ b/autotest/client/ruby/spec/onlysource/Translation_get_translations_spec.rb
@@ -23,7 +23,7 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about", 'en')).to eq({"component"=>"about", "locale"=>"en", "messages"=>{"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"}})
+            expect(Sgtn.get_translations("about", 'en')).to eq({"about.key1"=>"test value 1", "about.key2"=>"test value 2", "about.key3"=>"test value 3", "about.key4"=>"test value 4"})
         end
 
         it "get component by get_translations and component is int" do
@@ -48,12 +48,12 @@ describe "get_translations online test" do
         end
 
         it "get component by get_translations" do
-            expect(Sgtn.get_translations("about2", 'de')).to eq({"component"=>"about2", "locale"=>"en", "messages"=>{"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"}})
+            expect(Sgtn.get_translations("about2", 'de')).to eq({"about2.key1"=>"test value 1", "about2.key2"=>"test value 2"})
         end
 
         
         it "get component by get_translations and locale is en-UK" do
-            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"component"=>"intest", "locale"=>"en", "messages"=>{"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"}})
+            expect(Sgtn.get_translations("intest", "en_UK")).to eq({"intest.key1"=>"add value 1", "intest.key2"=>"add value source 2", "intest.key4"=>"add value 4"})
         end
 
 


### PR DESCRIPTION
because the return information format of method get_translations() is changed, so the smoke test code changed synchronously
old: get_translations() -> { 'component' = 'ABC', locale = 'en', messages = messages }
new: get_translations() -> {messages }