### PR TITLE
change type of 'pseudo' field in POST combine interface to fix #2035

### DIFF
--- a/api/v2/combine/handler_combine.go
+++ b/api/v2/combine/handler_combine.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2022-2023 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 

--- a/api/v2/combine/handler_combine.go
+++ b/api/v2/combine/handler_combine.go
@@ -6,6 +6,7 @@
 package combine
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -173,9 +174,24 @@ func getCombinedDataByPost(c *gin.Context) {
 		return
 	}
 
-	pseudo, err := strconv.ParseBool(params.Pseudo)
-	if err != nil && params.Pseudo != "" {
-		api.AbortWithError(c, sgtnerror.StatusBadRequest.WithUserMessage("%s isn't a boolean value", params.Pseudo))
+	var pseudo bool
+	var err error
+	switch v := params.Pseudo.(type) {
+	case nil:
+		pseudo = false
+	case string:
+		if v == "" {
+			pseudo = false
+		} else {
+			pseudo, err = strconv.ParseBool(v)
+		}
+	case bool:
+		pseudo = v
+	default:
+		err = errors.New("wrong type")
+	}
+	if err != nil {
+		api.AbortWithError(c, sgtnerror.StatusBadRequest.WrapErrorWithMessage(err, "%v is an invalid boolean value", params.Pseudo))
 		return
 	}
 

--- a/api/v2/combine/types_combine.go
+++ b/api/v2/combine/types_combine.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2022-2023 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 

--- a/api/v2/combine/types_combine.go
+++ b/api/v2/combine/types_combine.go
@@ -31,10 +31,10 @@ type (
 	translationWithPatternPostReq struct {
 		Combine int `form:"combine" binding:"oneof=1 2"`
 		translation.ReleaseID
-		Language   string   `form:"language" binding:"language"`
-		Region     string   `form:"region" binding:"omitempty,region"`
-		Components []string `form:"components" binding:"dive,component"`
-		Pseudo     string   `form:"pseudo" binding:"omitempty"`
+		Language   string      `form:"language" binding:"language"`
+		Region     string      `form:"region" binding:"omitempty,region"`
+		Components []string    `form:"components" binding:"dive,component"`
+		Pseudo     interface{} `form:"pseudo" binding:"omitempty"`
 		cldr.PatternScope
 	}
 )


### PR DESCRIPTION
Go service combine POST interface can accept both string type and boolean type as pseudo field.