### PR TITLE
Changing one of the testcases. The main reason, is the change in the …

### DIFF
--- a/autotest/client/python/main/testcases/cache/test_cache_offline_remote.py
+++ b/autotest/client/python/main/testcases/cache/test_cache_offline_remote.py
@@ -27,7 +27,7 @@ class TestCacheOfflineRemote:
 
         # get remote messages_de.json
         message = translation.get_string("about", "about.message", locale="de")
-        assert message == "test de key"
+        assert message == "test de key(Offline Disk)"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…config files, which contained URL from the internal network in VMWare. Theses cannot be used in GitHub actions, because they constitute security threat. They are replaced with files, that are saved locally. Because there is a difference in the files, one of the testcases should be modified accordingly.