### PR TITLE
Fix the build error:

### DIFF
--- a/g11n-ws/build.gradle
+++ b/g11n-ws/build.gradle
@@ -9,12 +9,12 @@ buildscript {
         mavenLocal()
         maven { url "https://repo1.maven.org/maven2/" }
         mavenCentral()
-        jcenter()
+        gradlePluginPortal()
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")
         classpath("org.asciidoctor:asciidoctor-gradle-plugin:1.5.7")
-        classpath("io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.3")
+        // classpath("io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.3")
         classpath("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1")
     }
 }
@@ -38,7 +38,6 @@ allprojects{
         mavenLocal() 
         maven { url "https://repo1.maven.org/maven2/" }
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
1) [jcenter] is deprecated: https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.dsl.RepositoryHandler.html
2) org.springframework.boot:spring-boot-gradle-plugin is in gradlePluginPortal() repo
3) swagger2markup-gradle-plugin:1.3.3 was released in 2018, and the following 2 dependecies no longer available. I don't see any build artifact difference with/without this plugin

* What went wrong: A problem occurred configuring root project 'singleton'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find org.asciidoctor:asciidoctor-gradle-plugin:1.5.7.
     Searched in the following locations:
       - file:/root/.m2/repository/org/asciidoctor/asciidoctor-gradle-plugin/1.5.7/asciidoctor-gradle-plugin-1.5.7.pom
       - https://repo1.maven.org/maven2/org/asciidoctor/asciidoctor-gradle-plugin/1.5.7/asciidoctor-gradle-plugin-1.5.7.pom - https://repo.maven.apache.org/maven2/org/asciidoctor/asciidoctor-gradle-plugin/1.5.7/asciidoctor-gradle-plugin-1.5.7.pom - https://jcenter.bintray.com/org/asciidoctor/asciidoctor-gradle-plugin/1.5.7/asciidoctor-gradle-plugin-1.5.7.pom Required by: project :
   > Could not find ch.netzwerg:paleo-core:0.11.0.
     Searched in the following locations:
       - file:/root/.m2/repository/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom
       - https://repo1.maven.org/maven2/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom - https://repo.maven.apache.org/maven2/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom - https://jcenter.bintray.com/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom Required by: project : > io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.3 > io.github.swagger2markup:swagger2markup:1.3.3
   > Could not find
nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.0.
     Searched in the following locations:
       - file:/root/.m2/repository/nl/jworks/markdown_to_asciidoc/markdown_to_asciidoc/1.0/markdown_to_asciidoc-1.0.pom
       - https://repo1.maven.org/maven2/nl/jworks/markdown_to_asciidoc/markdown_to_asciidoc/1.0/markdown_to_asciidoc-1.0.pom - https://repo.maven.apache.org/maven2/nl/jworks/markdown_to_asciidoc/markdown_to_asciidoc/1.0/markdown_to_asciidoc-1.0.pom - https://jcenter.bintray.com/nl/jworks/markdown_to_asciidoc/markdown_to_asciidoc/1.0/markdown_to_asciidoc-1.0.pom Required by: project : > io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.3 > io.github.swagger2markup:swagger2markup:1.3.3 >
io.github.swagger2markup:markup-document-builder:1.1.2