### PR TITLE
increase s3 client max connections from default 50

### DIFF
--- a/g11n-ws/modules/md-data-api-s3impl/src/main/java/com/vmware/vip/messages/data/conf/S3Client.java
+++ b/g11n-ws/modules/md-data-api-s3impl/src/main/java/com/vmware/vip/messages/data/conf/S3Client.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 VMware, Inc.
+ * Copyright 2019-2024 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 package com.vmware.vip.messages.data.conf;
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -112,8 +113,9 @@ public class S3Client {
 			   sessionCreds.getAccessKeyId(),
 			   sessionCreds.getSecretAccessKey(),
 			   sessionCreds.getSessionToken());
+	   ClientConfiguration clientConfiguration = new ClientConfiguration().withMaxErrorRetry(5).withMaxConnections(config.getS3ClientMaxConnections());
 	   return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(sessionCredentials))
-			.withRegion(config.getS3Region()).enablePathStyleAccess().build();
+			.withRegion(config.getS3Region()).withClientConfiguration(clientConfiguration).enablePathStyleAccess().build();
    }
    
 

--- a/g11n-ws/modules/md-data-api-s3impl/src/main/java/com/vmware/vip/messages/data/conf/S3Config.java
+++ b/g11n-ws/modules/md-data-api-s3impl/src/main/java/com/vmware/vip/messages/data/conf/S3Config.java
@@ -80,7 +80,8 @@ public class S3Config {
 	@Value("${allow.list.path.bucketName:}")
 	private String allowListBucketName;
 	
-	
+	@Value("${s3.client.max.connections:500}")
+	private int s3ClientMaxConnections;
 	
 	public String getAccessKey() {
 		if (this.encryption) {
@@ -157,6 +158,10 @@ public class S3Config {
 
 	public String getRoleArn() {
 		return roleArn;
+	}
+
+	public int getS3ClientMaxConnections() {
+		return s3ClientMaxConnections;
 	}
 
 	public String getAllowListBucketName() {


### PR DESCRIPTION
to fix error when query product based translation:
curl -k https://localhost:8090/i18n/api/v2/translation/products/CSP/versions/1.0?pseudo=false