### PR TITLE
Revert "Use S3 client DEFAULT_RETRY_POLICY"

### DIFF
--- a/g11n-ws/modules/md-data-api-s3impl/src/main/java/com/vmware/vip/messages/data/conf/S3Client.java
+++ b/g11n-ws/modules/md-data-api-s3impl/src/main/java/com/vmware/vip/messages/data/conf/S3Client.java
@@ -113,7 +113,7 @@ public class S3Client {
 			   sessionCreds.getAccessKeyId(),
 			   sessionCreds.getSecretAccessKey(),
 			   sessionCreds.getSessionToken());
-	   ClientConfiguration clientConfiguration = new ClientConfiguration().withMaxConnections(config.getS3ClientMaxConnections());
+	   ClientConfiguration clientConfiguration = new ClientConfiguration().withMaxErrorRetry(5).withMaxConnections(config.getS3ClientMaxConnections());
 	   return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(sessionCredentials))
 			.withRegion(config.getS3Region()).withClientConfiguration(clientConfiguration).enablePathStyleAccess().build();
    }


### PR DESCRIPTION
Reverts vmware/singleton#3204

During smoke API test, set up MaxErrorRetry is needed, otherwise, the test for curl -k https://127.0.0.1:8090/i18n/api/v2/translation/products/SingletonService/versions/1.0.1?pseudo=false might fail sometime with error "com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleRetryableException(AmazonHttpClient.java:1227) - Unable to execute HTTP request: The target server failed to respond"