### PR TITLE
add -XX:-UseContainerSupport

### DIFF
--- a/deploy/i18n-service/Dockerfile
+++ b/deploy/i18n-service/Dockerfile
@@ -7,4 +7,4 @@ ADD i18n-service.jar app.jar
 EXPOSE 8090
 EXPOSE 8091
 
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-XX:-UseContainerSupport", "-jar","/app.jar"]

--- a/performancetest/Dockerfile
+++ b/performancetest/Dockerfile
@@ -8,4 +8,4 @@ COPY l10n l10n
 EXPOSE 8090
 EXPOSE 8091
 
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-XX:-UseContainerSupport", "-jar","/app.jar"]


### PR DESCRIPTION
add -XX:-UseContainerSupport, otherwise, see exception:

Caused by: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null

See test run in https://github.com/vmware/singleton/actions/runs/22598006612