### PR TITLE
GCS - set ChunkSize to 64k from default 2M

### DIFF
--- a/g11n-ws/modules/md-data-api-gcsimpl/src/main/java/com/vmware/vip/messages/data/dao/gcs/impl/GcsComponentChannelDao.java
+++ b/g11n-ws/modules/md-data-api-gcsimpl/src/main/java/com/vmware/vip/messages/data/dao/gcs/impl/GcsComponentChannelDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 VMware, Inc.
+ * Copyright 2019-2026 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 package com.vmware.vip.messages.data.dao.gcs.impl;
@@ -32,6 +32,7 @@ import com.vmware.vip.messages.data.gcs.util.GcsUtils;
 @Repository
 public class GcsComponentChannelDao implements IComponentChannelDao {
     private static Logger logger = LoggerFactory.getLogger(GcsComponentChannelDao.class);
+    private static final int CHUNK_SIZE = 64 * 1024;
 
     @Autowired
     private GcsClient gcsClient;
@@ -53,6 +54,7 @@ public class GcsComponentChannelDao implements IComponentChannelDao {
                 Blob blob = gcsClient.getGcsStorage().get(blobId);
                 if (blob != null) {
                 	ReadChannel readChannel = blob.reader();
+                	readChannel.setChunkSize(CHUNK_SIZE);
                 	InputStream is = Channels.newInputStream(readChannel);
                     resultChannels.add(new ResultMessageChannel(component, locale, Channels.newChannel(is)));           
                 }

--- a/g11n-ws/modules/md-restful-api-i18n/src/main/java/com/vmware/vip/core/except/ExceptionHandle.java
+++ b/g11n-ws/modules/md-restful-api-i18n/src/main/java/com/vmware/vip/core/except/ExceptionHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 VMware, Inc.
+ * Copyright 2019-2026 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 package com.vmware.vip.core.except;
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -67,6 +68,10 @@ public class ExceptionHandle {
 			logger.error("====== HTTP Exception =======");
 			logger.error(e.getMessage());
 			response.setResponse(new Response(APIResponseStatus.INTERNAL_SERVER_ERROR.getCode(), e.getMessage()));
+		} else if (e instanceof HttpMessageNotReadableException) {
+			logger.error("====== HttpMessageNotReadableException =======");
+			logger.error(e.getMessage());
+			response.setResponse(new Response(APIResponseStatus.BAD_REQUEST.getCode(), "Required request body is missing"));
 		} else {
 			response.setResponse(new Response(APIResponseStatus.UNKNOWN_ERROR.getCode(), e.getMessage()));
 			String errorStr = MessageFormat.format("unknown error: {0}" ,e.getMessage());

--- a/g11n-ws/modules/md-restful-api-i18n/src/main/java/com/vmware/vip/i18n/api/base/StreamProductAction.java
+++ b/g11n-ws/modules/md-restful-api-i18n/src/main/java/com/vmware/vip/i18n/api/base/StreamProductAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 VMware, Inc.
+ * Copyright 2019-2026 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 package com.vmware.vip.i18n.api.base;
@@ -16,6 +16,8 @@ import com.vmware.vip.messages.data.dao.model.ResultMessageChannel;
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,6 +35,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class StreamProductAction extends TranslationProductAction {
+    private static Logger logger = LoggerFactory.getLogger(StreamProductAction.class);
     private static byte[] byteComm = (ConstantsChar.COMMA + "\r\n").getBytes();
 
     @Autowired
@@ -176,6 +179,15 @@ public class StreamProductAction extends TranslationProductAction {
             } else {
                 buf.put(byteComm);
             }
+            if (logger.isDebugEnabled()) {
+                Runtime runtime = Runtime.getRuntime();
+                long maxMemory = runtime.maxMemory();       // -Xmx configuration limit
+                long totalMemory = runtime.totalMemory();   // Currently allocated to the JVM
+                long freeMemory = runtime.freeMemory();     // Unused portion of total allocated memory
+                long usedMemory = totalMemory - freeMemory; // Memory actively holding objects
+                logger.debug("FreeMemory: {}, UsedMemory: {}, TotalMemory: {}", freeMemory, usedMemory, totalMemory);
+            }
+
             transferTo(readChannels.get(idx).getReadableByteChannel(), wbc, buf);
         }
     }

--- a/g11n-ws/vip-manager-i18n/src/main/java/com/vmware/vip/core/Interceptor/APICrossDomainInterceptor.java
+++ b/g11n-ws/vip-manager-i18n/src/main/java/com/vmware/vip/core/Interceptor/APICrossDomainInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 VMware, Inc.
+ * Copyright 2019-2026 VMware, Inc.
  * SPDX-License-Identifier: EPL-2.0
  */
 package com.vmware.vip.core.Interceptor;
@@ -30,8 +30,13 @@ public class APICrossDomainInterceptor implements HandlerInterceptor {
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
 			throws Exception {
 		String originHeader = request.getHeader("Origin");
-		if (allowOrigin.contains("*") || allowOrigin.contains(originHeader)) {
-			response.setHeader("Access-Control-Allow-Origin", originHeader == null ? "" : originHeader);
+		if (allowOrigin.contains("*")) {
+			response.setHeader("Access-Control-Allow-Origin", "*");
+			response.setHeader("Access-Control-Allow-Methods", allowMethods);
+			response.setHeader("Access-Control-Allow-Headers", allowHeaders);
+			response.setHeader("Access-Control-Max-Age", maxAge);
+		} else if (allowOrigin.contains(originHeader)) {
+			response.setHeader("Access-Control-Allow-Origin", originHeader);
 			response.setHeader("Access-Control-Allow-Methods", allowMethods);
 			response.setHeader("Access-Control-Allow-Headers", allowHeaders);
 			response.setHeader("Access-Control-Allow-Credentials", allowCredentials);

--- a/g11n-ws/vip-manager-i18n/src/main/resources/application-bundle.properties
+++ b/g11n-ws/vip-manager-i18n/src/main/resources/application-bundle.properties
@@ -1,5 +1,5 @@
 ##
-#Copyright 2019-2022 VMware, Inc.
+#Copyright 2019-2026 VMware, Inc.
 #SPDX-License-Identifier: EPL-2.0
 ##
 
@@ -71,7 +71,7 @@ vipservice.authority.ldap.searchbase=###
 
 #cross-domain configuration
 vipservice.cross.domain.enable=true
-vipservice.cross.domain.allowCredentials=true
+vipservice.cross.domain.allowCredentials=false
 vipservice.cross.domain.alloworigin=*
 vipservice.cross.domain.allowmethods=GET, POST, PUT, DELETE, OPTIONS
 vipservice.cross.domain.allowheaders=csp-auth-token, Content-Type, x-xmp-ui, Authorization

--- a/g11n-ws/vip-manager-i18n/src/main/resources/application-gcs.properties
+++ b/g11n-ws/vip-manager-i18n/src/main/resources/application-gcs.properties
@@ -1,5 +1,5 @@
 ##
-#Copyright 2019-2022 VMware, Inc.
+#Copyright 2019-2026 VMware, Inc.
 #SPDX-License-Identifier: EPL-2.0
 ##
 
@@ -69,7 +69,7 @@ vipservice.authority.ldap.searchbase=####
 
 #cross-domain configuration
 vipservice.cross.domain.enable=true
-vipservice.cross.domain.allowCredentials=true
+vipservice.cross.domain.allowCredentials=false
 vipservice.cross.domain.alloworigin=*
 vipservice.cross.domain.allowmethods=GET, POST, PUT, DELETE, OPTIONS
 vipservice.cross.domain.allowheaders=csp-auth-token, Content-Type, x-xmp-ui, Authorization

--- a/g11n-ws/vip-manager-i18n/src/main/resources/application-s3.properties
+++ b/g11n-ws/vip-manager-i18n/src/main/resources/application-s3.properties
@@ -1,5 +1,5 @@
 ##
-#Copyright 2019-2022 VMware, Inc.
+#Copyright 2019-2026 VMware, Inc.
 #SPDX-License-Identifier: EPL-2.0
 ##
 
@@ -76,7 +76,7 @@ vipservice.authority.ldap.searchbase=####
 
 #cross-domain configuration
 vipservice.cross.domain.enable=true
-vipservice.cross.domain.allowCredentials=true
+vipservice.cross.domain.allowCredentials=false
 vipservice.cross.domain.alloworigin=*
 vipservice.cross.domain.allowmethods=GET, POST, PUT, DELETE, OPTIONS
 vipservice.cross.domain.allowheaders=csp-auth-token, Content-Type, x-xmp-ui, Authorization


### PR DESCRIPTION
when query by product/version in GCS deployment:
/i18n/api/v2/translation/products/$(Product)/versions/$(Version) with many hundreds of components, the service might encounter java.lang.OutOfMemoryError

enhance the error code/message for post with empty body